### PR TITLE
add total steps option to the numbers in Helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 /dist
 /lib
+.idea/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="JSX" />
+  </component>
+</project>

--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -58,6 +58,7 @@ class TourPortal extends Component {
     showNavigationNumber: true,
     showButtons: true,
     showNumber: true,
+    showTotalSteps: false,
     scrollDuration: 1,
     maskSpace: 10,
     updateDelay: 1,
@@ -310,6 +311,7 @@ Please check the \`steps\` Tour prop Array at position: ${current + 1}.`)
       lastStepNextButton,
       nextButton,
       prevButton,
+      showTotalSteps
     } = this.props
 
     const {
@@ -384,6 +386,8 @@ Please check the \`steps\` Tour prop Array at position: ${current + 1}.`)
             tabIndex={-1}
             current={current}
             showNumber={showNumber}
+            showTotalSteps={showTotalSteps}
+            totalSteps={steps.length}
             style={steps[current].style ? steps[current].style : {}}
             className={cn(CN.helper.base, className, {
               [CN.helper.isOpen]: isOpen,

--- a/src/components.js
+++ b/src/components.js
@@ -18,7 +18,7 @@ export const Helper = styled.div`
   padding-right: 40px;
   
   &:after {
-    content: '${props => props.current + 1}';
+    content: "${props => props.current + 1}${props => props.showTotalSteps ? props => {return '/' + props.totalSteps} : null}";
     position: absolute;
     font-family: monospace;
     background-color: var(--reactour-accent);


### PR DESCRIPTION
Hi, our user tests results show that the user fill more secure to know how much steps remained in the tour so, i thought it will be nice to add it to the Reactour widget, off course it's optional field.