### PR TITLE
Fix startAt and onAfterOpen always taken from previous props

### DIFF
--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -112,7 +112,7 @@ class TourPortal extends Component {
     const { isOpen, update, updateDelay } = this.props
 
     if (!isOpen && nextProps.isOpen) {
-      this.open()
+      this.open(nextProps)
     } else if (isOpen && !nextProps.isOpen) {
       this.close()
     }
@@ -141,8 +141,8 @@ class TourPortal extends Component {
     }
   }
 
-  open() {
-    const { onAfterOpen, startAt } = this.props
+  open(nextProps) {
+    const { onAfterOpen, startAt } = nextProps !== undefined ? nextProps : this.props
     this.setState(
       prevState => ({
         isOpen: true,


### PR DESCRIPTION
`startAt` and `onAfterOpen` were always taken from the previous props when opening the tour.
So for example passing `startAt` was only taken into effect the next time the tour would open.

I have changed the `open` to accept a `nextProps` parameter, the values are then taken from there.
If no `nextProps`  is provided the method will use the current `this.props`.