### PR TITLE
cleanup on mutation observer

### DIFF
--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -184,7 +184,7 @@ class TourPortal extends Component {
         prevState => {
           if (prevState.observer) {
             setTimeout(() => {
-              //prevState.observer.disconnect()
+              prevState.observer.disconnect()
             }, 0);
           }
           return {

--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -142,9 +142,6 @@ class TourPortal extends Component {
     }
     if (this.state.observer) {
       this.state.observer.disconnect()
-      this.setState({
-        observer: null,
-      })
     }
   }
 
@@ -187,7 +184,7 @@ class TourPortal extends Component {
         prevState => {
           if (prevState.observer) {
             setTimeout(() => {
-              prevState.observer.disconnect()
+              //prevState.observer.disconnect()
             }, 0);
           }
           return {


### PR DESCRIPTION
Currently there is an bug on demo page: go to the last step(step 10), click on button "show extra buildings", then close tour. Click on button "hide extra buildings", console would show `Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null`.

This is because MutationObserver is not properly disconnected after tour is closed, thus the changes in `componentWillUnmount`.

Upon further investigation, when new MutationObserver gets connected within the same step, old ones don't get disconnected. The above scenario is extremely common, it could because of resize triggering `showStep`, or parent component state changes, like the demo application(clicking button would toggle `isShowingMore` state, which is the parent app's state). So there would be multiple duplicate MutationObserver registered on the same target. Thus `setState` would disconnect the previous state stored MutationObserver.