### PR TITLE
Add a class for the active navigation dot

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -517,6 +517,9 @@ class Tour extends Component {
                         disabled={current === i || disableDotsNavigation}
                         showNumber={showNavigationNumber}
                         data-tour-elem="dot"
+                        className={cn(CN.dot.base, {
+                          [CN.dot.active]: current === i,
+                        })}
                       />
                     ))}
                   </Navigation>
@@ -568,6 +571,10 @@ const CN = {
   helper: {
     base: 'reactour__helper',
     isOpen: 'reactour__helper--is-open',
+  },
+  dot: {
+    base: 'reactour__dot',
+    active: 'reactour__dot--is-active',
   },
 }
 


### PR DESCRIPTION
This is a solution for https://github.com/elrumordelaluz/reactour/issues/103.

Added the class name `reactour__dot--active`. I tried to follow your class naming convention but am happy to change it to whatever you prefer.