### PR TITLE
Disable ESC closing tour if CloseButton is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,14 @@ Type: `bool`
 
 #### disableKeyboardNavigation
 
-> Disable keyboard navigation (next and prev step)
+> Disable all keyboard navigation (next and prev step) when true, disable only selected keys when array
 
-Type: `bool`
+Type: `bool | array(['esc', 'right', 'left'])`
+
+```js
+// example
+<Tour disableKeyboardNavigation={['esc']} />
+```
 
 #### getCurrentStep
 

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -64,7 +64,10 @@ class Tour extends Component {
     updateDelay: PropTypes.number,
     disableInteraction: PropTypes.bool,
     disableDotsNavigation: PropTypes.bool,
-    disableKeyboardNavigation: PropTypes.bool,
+    disableKeyboardNavigation: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.oneOf(['esc', 'right', 'left'])),
+      PropTypes.bool
+    ]),
     rounded: PropTypes.number,
     accentColor: PropTypes.string,
   }
@@ -364,21 +367,21 @@ class Tour extends Component {
     } = this.props
     e.stopPropagation()
 
-    if (disableKeyboardNavigation) {
+    if (disableKeyboardNavigation === true) {
       return
     }
 
-    if (e.keyCode === 27 && showCloseButton) {
+    if (e.keyCode === 27 && !disableKeyboardNavigation.contains('esc')) {
       // esc
       e.preventDefault()
       onRequestClose()
     }
-    if (e.keyCode === 39) {
+    if (e.keyCode === 39 && !disableKeyboardNavigation.contains('right')) {
       // right
       e.preventDefault()
       typeof nextStep === 'function' ? nextStep() : this.nextStep()
     }
-    if (e.keyCode === 37) {
+    if (e.keyCode === 37 && !disableKeyboardNavigation.includes('left')) {
       // left
       e.preventDefault()
       typeof prevStep === 'function' ? prevStep() : this.prevStep()

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -360,6 +360,7 @@ class Tour extends Component {
       nextStep,
       prevStep,
       disableKeyboardNavigation,
+      showCloseButton,
     } = this.props
     e.stopPropagation()
 
@@ -367,7 +368,7 @@ class Tour extends Component {
       return
     }
 
-    if (e.keyCode === 27) {
+    if (e.keyCode === 27 && showCloseButton) {
       // esc
       e.preventDefault()
       onRequestClose()

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -371,20 +371,30 @@ class Tour extends Component {
       return
     }
 
-    if (e.keyCode === 27 && !disableKeyboardNavigation.contains('esc')) {
+    let isEscDisabled, isRightDisabled, isLeftDisabled;
+
+    if (disableKeyboardNavigation) {
+      isEscDisabled = disableKeyboardNavigation.includes('esc');
+      isRightDisabled = disableKeyboardNavigation.includes('right');
+      isLeftDisabled = disableKeyboardNavigation.includes('left');
+    }
+
+    if (e.keyCode === 27 && !isEscDisabled) {
       // esc
-      e.preventDefault()
-      onRequestClose()
+      e.preventDefault();
+      onRequestClose();
     }
-    if (e.keyCode === 39 && !disableKeyboardNavigation.contains('right')) {
+
+    if (e.keyCode === 39 && !isRightDisabled) {
       // right
-      e.preventDefault()
-      typeof nextStep === 'function' ? nextStep() : this.nextStep()
+      e.preventDefault();
+      typeof nextStep === 'function' ? nextStep() : _this.nextStep();
     }
-    if (e.keyCode === 37 && !disableKeyboardNavigation.includes('left')) {
+
+    if (e.keyCode === 37 && !isLeftDisabled) {
       // left
-      e.preventDefault()
-      typeof prevStep === 'function' ? prevStep() : this.prevStep()
+      e.preventDefault();
+      typeof prevStep === 'function' ? prevStep() : _this.prevStep();
     }
   }
 

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -381,20 +381,20 @@ class Tour extends Component {
 
     if (e.keyCode === 27 && !isEscDisabled) {
       // esc
-      e.preventDefault();
-      onRequestClose();
+      e.preventDefault()
+      onRequestClose()
     }
 
     if (e.keyCode === 39 && !isRightDisabled) {
       // right
-      e.preventDefault();
-      typeof nextStep === 'function' ? nextStep() : _this.nextStep();
+      e.preventDefault()
+      typeof nextStep === 'function' ? nextStep() : this.nextStep()
     }
 
     if (e.keyCode === 37 && !isLeftDisabled) {
       // left
-      e.preventDefault();
-      typeof prevStep === 'function' ? prevStep() : _this.prevStep();
+      e.preventDefault()
+      typeof prevStep === 'function' ? prevStep() : this.prevStep()
     }
   }
 


### PR DESCRIPTION
Remove ability to close tour guide when showCloseButton is set to false, to prevent users from bypassing disabled close button