### PR TITLE
Pre/post/rewind actions and documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,13 @@ Type: `node`
 
 #### nextStep
 
-> Overrides default `nextStep` internal function
+> Overrides default `nextStep` internal function. Gets passed the default `nextStep` handler as a parameter, so you can choose to execute it based on a requirement. Strange behaviour is expected if you change the current step then also execute the default implementation!
 
 Type: `func`
+
+```js
+<Tour prevStep={(defaultNext) => someRequirement && defaultNext()} />
+```
 
 #### onAfterOpen
 
@@ -244,9 +248,13 @@ Type: `node`
 
 #### prevStep
 
-> Overrides default `prevStep` internal function
+> Overrides default `prevStep` internal function. Gets passed the default `prevStep` handler as a parameter, so you can choose to execute it based on a requirement. Strange behaviour is expected if you change the current step then also execute the default implementation!
 
 Type: `func`
+
+```js
+<Tour prevStep={(defaultPrev) => someRequirement && defaultPrev()} />
+```
 
 #### rounded
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Type: `number`
 
 #### steps
 
-> Array of elements to highligt with special info and props
+> Array of elements to highlight with special info and props
 
 Type: `shape`
 
@@ -332,6 +332,9 @@ steps: PropTypes.arrayOf(PropTypes.shape({
   'action': PropTypes.func,
   'style': PropTypes.object,
   'stepInteraction': PropTypes.bool,
+  'preAction': propTypes.func,
+  'postAction': propTypes.func,
+  'rewindAction': propTypes.func
 })),
 ```
 
@@ -361,6 +364,16 @@ const steps = [
     // Could be enabled passing `true`
     // when `disableInteraction` prop is present in Tour
     stepInteraction: false,
+    preAction: () => {
+        // this is executed before this step starts
+        // preActions will NOT run if used on the first step
+        console.log("Step is about to start")
+    },
+    postAction: () => {
+        // this is executed before this step ends
+        // postActions will NOT run if used on the last step
+        console.log("Step is about to finish")
+    }
   },
   // ...
 ]
@@ -380,11 +393,69 @@ Type: `number`
 
 Default: `1`
 
+### Step props
+
+#### content
+
+> The content of the step, which can be simple text, a node, element or a function that returns any of these.
+
+Type: `node`|`element`|`func`
+
+Required: true
+
+#### observe
+
+> Watches an element for changes and updates the spotlight accordingly
+
+Type: `node`
+
+#### position
+
+> Where the step modal will appear relative to the selected element.
+
+Type: `func`
+
+#### preAction
+
+> Action handler that is executed before this step executes.
+
+Type: `func`
+
+#### postAction
+
+> Action handler that is executed after this step executes.
+
+Type: `func`
+
+#### rewindAction
+
+> Action handler that is executed if this step is rewinded (for resetting)
+
+Type: `func`
+
+#### selector
+
+> This string is used with [`document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) to select the element for this step.
+
+Type: `string`
+
+#### stepInteraction
+
+> Disables interaction only for this step, rather than needing to enable it globally with `disableInteraction`.
+
+Type: `func`
+
+#### style
+
+> CSS/style to be applied to this step only. Pass as an object (or inline CSS).
+
+Type: `object`
+
 ## FAQ
 
 <p>
   <details>
-    <summary>How is implemented the scroll lock behaviour in the <a href="https://github.com/elrumordelaluz/reactour/blob/master/src/demo/App.js">Demo</a>?</summary>
+    <summary>How is the scroll lock behaviour implemented in the <a href="https://github.com/elrumordelaluz/reactour/blob/master/src/demo/App.js">Demo</a>?</summary>
     <p>
       To guarantee a cross browser behaviour we use <a href="https://www.npmjs.com/package/body-scroll-lock">body-scroll-lock</a>. </p>
       <p>Import the library
@@ -403,6 +474,52 @@ enableBody = target => enableBodyScroll(target)</pre>
   onAfterOpen={this.disableBody}
   onBeforeClose={this.enableBody}
 /&gt;</pre>
+    </p>
+  </details>
+</p>
+
+<p>
+  <details>
+    <summary>Why should I use pre instead of post? I can just use post in the step before (and vice versa).</summary>
+    <p>
+      In many cases, choosing between the pre & post action will not matter to the actual tour. They are mainly there to logically separate actions for the programmer.
+    </p>
+    <p>
+      Look at the example below to see an example of where this might help writing steps.
+
+      First of all, the bad version:
+    </p>
+    <pre lang=js>
+    [
+      {
+        selector: '#modal',
+        content: 'Here you can enter data'
+        postAction: () => openTheDropdown()
+      },
+      {
+        selector: '#the-dropdown',
+        content: 'Here is the dropdown'
+      },
+    ]
+    </pre>
+    <p>
+      This works, but why should the modal step care about the dropdown? In this case, the `preAction` handler makes more sense:
+    </p>
+    <pre lang=js>
+    [
+      {
+        selector: '#modal',
+        content: 'Here you can enter data'
+      },
+      {
+        selector: '#the-dropdown',
+        content: 'Here is the dropdown',
+        preAction: () => openTheDropdown()
+      },
+    ]
+    </pre>
+    <p>
+      Now if you have a lot of tour steps, each step is well separated in scope.
     </p>
   </details>
 </p>

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Type: `bool`
 
 Default: `true`
 
+#### deterministic
+
+> If jumping between steps (e.g. with dots) should we attempt to execute all preAction/action/postAction (or rewind) handlers in between? The element of each step (step.selector) is parsed and passed to each function, but may not be completely accurate, due to the fact that each step has to be replayed quickly - some UI elements may not respond quickly enough.
+
+Type: `bool`
+
+Default: `true`
+
 #### disableDotsNavigation
 
 > Disable interactivity with _Dots_ navigation in _Helper_
@@ -415,11 +423,25 @@ Type: `node`
 
 Type: `func`
 
+#### action
+
+> Action handler that is executed after this step executes.
+
+Type: `func`
+
+Parameters: `node`
+
+Resolves [`step.selector`](#selector) as a node (with [`document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)) and passed to this handler.
+
 #### preAction
 
 > Action handler that is executed before this step executes.
 
 Type: `func`
+
+Parameters: `node`
+
+See [`action`](#action)
 
 #### postAction
 
@@ -427,11 +449,19 @@ Type: `func`
 
 Type: `func`
 
+Parameters: `node`
+
+See [`action`](#action)
+
 #### rewindAction
 
 > Action handler that is executed if this step is rewinded (for resetting)
 
 Type: `func`
+
+Parameters: `node`
+
+This performs the same role as the parameter for preAction, Action and postAction, but as the step is backwards, this may not be as reliable.
 
 #### selector
 
@@ -482,44 +512,46 @@ enableBody = target => enableBodyScroll(target)</pre>
   <details>
     <summary>Why should I use pre instead of post? I can just use post in the step before (and vice versa).</summary>
     <p>
-      In many cases, choosing between the pre & post action will not matter to the actual tour. They are mainly there to logically separate actions for the programmer.
+In many cases, choosing between the pre & post action will not matter to the actual tour. They are mainly there to logically separate actions for the programmer.
     </p>
     <p>
-      Look at the example below to see an example of where this might help writing steps.
+Look at the example below to see an example of where this might help writing steps.
 
-      First of all, the bad version:
+The bad version:
     </p>
     <pre lang=js>
-    [
-      {
-        selector: '#modal',
-        content: 'Here you can enter data'
-        postAction: () => openTheDropdown()
-      },
-      {
-        selector: '#the-dropdown',
-        content: 'Here is the dropdown'
-      },
-    ]
+[
+  {
+    selector: '#modal',
+    content: 'Here you can enter data'
+    postAction: () => openTheDropdown()
+  },
+  {
+    selector: '#the-dropdown',
+    content: 'Here is the dropdown'
+  },
+]
     </pre>
     <p>
-      This works, but why should the modal step care about the dropdown? In this case, the `preAction` handler makes more sense:
+This works, but why should the modal step care about the dropdown? In this case, the `preAction` handler makes more sense.
+
+The better version:
     </p>
     <pre lang=js>
-    [
-      {
-        selector: '#modal',
-        content: 'Here you can enter data'
-      },
-      {
-        selector: '#the-dropdown',
-        content: 'Here is the dropdown',
-        preAction: () => openTheDropdown()
-      },
-    ]
+[
+  {
+    selector: '#modal',
+    content: 'Here you can enter data'
+  },
+  {
+    selector: '#the-dropdown',
+    content: 'Here is the dropdown',
+    preAction: () => openTheDropdown()
+  },
+]
     </pre>
     <p>
-      Now if you have a lot of tour steps, each step is well separated in scope.
+Now if you have a lot of tour steps, each step is well separated in scope.
     </p>
   </details>
 </p>

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -269,6 +269,18 @@ class Tour extends Component {
         getCurrentStep(nextStep)
       }
 
+      if(prevState.current !== nextStep) {
+        if(steps[prevState.current].postAction && steps[prevState.current].postAction instanceof Function) {
+          steps[prevState.current].postAction()
+        }
+
+        if(steps[nextStep].preAction && steps[nextStep].preAction instanceof Function) {
+          steps[nextStep].preAction()
+        }
+      }
+
+
+
       return {
         current: nextStep,
       }
@@ -276,10 +288,14 @@ class Tour extends Component {
   }
 
   prevStep = () => {
-    const { getCurrentStep } = this.props
+    const { steps, getCurrentStep } = this.props
     this.setState(prevState => {
       const nextStep =
         prevState.current > 0 ? prevState.current - 1 : prevState.current
+
+      if(prevState.current !== nextStep && steps[nextStep].rewind && steps[nextStep].rewind instanceof Function) {
+        steps[nextStep].rewind()
+      }
 
       if (typeof getCurrentStep === 'function') {
         getCurrentStep(nextStep)

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -383,13 +383,17 @@ class Tour extends Component {
     if (e.keyCode === 39 && !isRightDisabled) {
       // right
       e.preventDefault()
-      typeof nextStep === 'function' ? nextStep() : this.nextStep()
+      typeof nextStep === 'function'
+        ? nextStep(this.nextStep.bind(this))
+        : this.nextStep()
     }
 
     if (e.keyCode === 37 && !isLeftDisabled) {
       // left
       e.preventDefault()
-      typeof prevStep === 'function' ? prevStep() : this.prevStep()
+      typeof prevStep === 'function'
+        ? prevStep(this.prevStep.bind(this))
+        : this.prevStep()
     }
   }
 
@@ -534,7 +538,7 @@ class Tour extends Component {
                         <Arrow
                           onClick={
                             typeof prevStep === 'function'
-                              ? prevStep
+                              ? () => prevStep(this.prevStep.bind(this))
                               : this.prevStep
                           }
                           disabled={current === 0}
@@ -570,8 +574,8 @@ class Tour extends Component {
                                 ? onRequestClose
                                 : () => {}
                               : typeof nextStep === 'function'
-                              ? nextStep
-                              : this.nextStep
+                                ? () => nextStep(this.nextStep.bind(this))
+                                : this.nextStep
                           }
                           disabled={
                             !lastStepNextButton && current === steps.length - 1

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -227,14 +227,21 @@ const tourConfig = (setShowingMoreHandler) => [
       'As soon as you arrive on a step you can perform actions, like… (look at the console)',
     preAction: () =>
         console.log(`
+                             [PRE-ACTION]
+           This handler executes just before the step starts to begin,
+              making it a good place to setup for this step.
 
                       ----------🕒-🕒-----------
               You can even perform actions in between steps,
-      such as making sure a dropdown is open before the next step loads...
+      e.g. making sure a dropdown is open before the next step loads...
                       ----------🕒-🕒-----------
         `),
     action: () =>
           console.log(`
+                               [ACTION]
+        This handler executes when the step/dialog has fully landed
+              on the selector and displayed 'step.content'.
+
                       -----------🏠🏚----------
           🚌 Arrived to explore these beautiful buildings! 🚌
                       -----------🏠🏚----------
@@ -242,6 +249,10 @@ const tourConfig = (setShowingMoreHandler) => [
         `),
     postAction: () =>
         console.log(`
+                            [POST-ACTION]
+        This handler executes just before moving on to the next step
+        and should generally be used for cleanup of the current step.
+
                       ----------🕒-🕒-----------
             ...or the dropdown is closed for the next one,
           Whichever makes the most semantic sense is up to you!
@@ -254,7 +265,7 @@ const tourConfig = (setShowingMoreHandler) => [
       'And the Tour could be observing changes to update the view, try clicking the button…',
     observe: '[data-tut="reactour__state--observe"]',
     action: node => node.focus(),
-    rewind: () => {
+    rewindAction: () => {
       setShowingMoreHandler(false)
       console.log("🕒 Timewarp in progress... 🕒")
     }

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -54,7 +54,7 @@ function App() {
           onAfterOpen={disableBody}
           onBeforeClose={enableBody}
           onRequestClose={() => setOpen(false)}
-          steps={tourConfig}
+          steps={tourConfig(setShowingMore)}
           isOpen={isTourOpen}
           maskClassName="mask"
           className="helper"
@@ -119,7 +119,7 @@ function MyCustomHelper({ current, content, totalSteps, gotoStep, close }) {
   )
 }
 
-const tourConfig = [
+const tourConfig = (setShowingMoreHandler) => [
   {
     selector: '[data-tut="reactour__iso"]',
     content:
@@ -224,14 +224,29 @@ const tourConfig = [
   {
     selector: '[data-tut="reactour__action"]',
     content:
-      'When arrived on each place you could fire an action, like… (look at the console)',
+      'As soon as you arrive on a step you can perform actions, like… (look at the console)',
+    preAction: () =>
+        console.log(`
+
+                      ----------🕒-🕒-----------
+              You can even perform actions in between steps,
+      such as making sure a dropdown is open before the next step loads...
+                      ----------🕒-🕒-----------
+        `),
     action: () =>
-      console.log(`
-                  ------------🏠🏚---------
-      🚌 Arrived to explore these beautiful buildings! 🚌
-                  ------------🏠🏚---------
-   🚧 This action could also fire a method in your Component 🚧
-    `),
+          console.log(`
+                      -----------🏠🏚----------
+          🚌 Arrived to explore these beautiful buildings! 🚌
+                      -----------🏠🏚----------
+       🚧 This action could also fire a method in your Component 🚧
+        `),
+    postAction: () =>
+        console.log(`
+                      ----------🕒-🕒-----------
+            ...or the dropdown is closed for the next one,
+          Whichever makes the most semantic sense is up to you!
+                      ----------🕒-🕒-----------
+        `),
   },
   {
     selector: '[data-tut="reactour__state"]',
@@ -239,6 +254,15 @@ const tourConfig = [
       'And the Tour could be observing changes to update the view, try clicking the button…',
     observe: '[data-tut="reactour__state--observe"]',
     action: node => node.focus(),
+    rewind: () => {
+      setShowingMoreHandler(false)
+      console.log("🕒 Timewarp in progress... 🕒")
+    }
+  },
+  {
+    selector: '[data-tut="reactour__state"]',
+    content:
+      'Whoops - we\'ve made a change to the page\'s state... If we go backwards the tour might be depend on the buildings being hidden! See what happens when you rewind this step.',
   },
 ]
 

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -55,6 +55,7 @@ export const propTypes = {
   ]),
   rounded: PropTypes.number,
   accentColor: PropTypes.string,
+  deterministic: PropTypes.bool
 }
 
 export const defaultProps = {
@@ -70,4 +71,5 @@ export const defaultProps = {
   rounded: 0,
   accentColor: '#007aff',
   closeWithMask: true,
+  deterministic: true
 }

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -40,6 +40,9 @@ export const propTypes = {
       action: PropTypes.func,
       style: PropTypes.object,
       stepInteraction: PropTypes.bool,
+      preAction: PropTypes.func,
+      postAction: PropTypes.func,
+      rewindAction: PropTypes.func
     })
   ),
   update: PropTypes.string,


### PR DESCRIPTION
Hi,

I've been using this library for about a week now on a project and what I really liked about it is that you don't even need to fork it to override how it works. I've been using my own `prevStep` and `nextStep` functions to achieve everything successfully in this PR - and I feel like having these things inside the library would be really useful.

## Pre/post actions
Basically, these actions run in-between steps which is really useful for setting up a complex interaction - such as opening a dropdown and then selecting the item. There are seperate `pre` and `post` actions to tidy up the step definitions.

E.g. if you have a dropdown, maybe you wrote your steps like this:

```js
[
  {
    selector: '#modal',
    content: 'Here you can enter data'
    postAction: () => openTheDropdown()
  },
  {
    selector: '#the-dropdown',
    content: 'Here is the dropdown'
  },
]
```

This is fine and works, but it's messy, because the modal step is doing things with the dropdown.

It makes far more sense to define the steps this way:

```js
[
  {
    selector: '#modal',
    content: 'Here you can enter data'
  },
  {
    selector: '#the-dropdown',
    content: 'Here is the dropdown',
    preAction: () => openTheDropdown()
  },
]
```

***

## Rewind action
In my tutorial, I often select items and click things which changes the state. If the user wants to go back a couple of steps, the tutorial won't work properly, as the elements that each step depended on have changed or gone completely. The `rewindAction()` handles this by only being called when going backwards.

---

Hopefully that all makes sense!
Peter
