### PR TITLE
Add option to add aria-label attribute to each step's navigation dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Type: `number`
 
 #### steps
 
-> Array of elements to highligt with special info and props
+> Array of elements to highlight with special info and props
 
 Type: `shape`
 
@@ -335,6 +335,7 @@ steps: PropTypes.arrayOf(PropTypes.shape({
   'action': PropTypes.func,
   'style': PropTypes.object,
   'stepInteraction': PropTypes.bool,
+  'navDotAriaLabel': PropTypes.string,
 })),
 ```
 
@@ -366,6 +367,8 @@ const steps = [
     // Could be enabled passing `true`
     // when `disableInteraction` prop is present in Tour
     stepInteraction: false,
+    // Text read to screen reader software for this step's navigation dot
+    navDotAriaLabel: 'Go to step 4',
   },
   // ...
 ]

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -347,6 +347,7 @@ function Tour({
                           className={cn(CN.dot.base, {
                             [CN.dot.active]: current === i,
                           })}
+                          aria-label={s.navDotAriaLabel}
                         />
                       ))}
                     </Navigation>

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -44,6 +44,7 @@ export const propTypes = {
       actionBefore: PropTypes.func,
       style: PropTypes.object,
       stepInteraction: PropTypes.bool,
+      navDotAriaLabel: PropTypes.string,
     })
   ),
   update: PropTypes.string,


### PR DESCRIPTION
Currently, the navigation dots have no semantic information or meaning, so screen reader users will not know what those buttons do.

This PR adds a new property `navDotAriaLabel` to each `steps` object, which takes a string and renders it in the dot's markup as an `aria-label`.

So this step...
```
 {
    selector: '[data-tut="reactour__copy"]',
    content: `Keep in mind that you could try and test everything during the Tour.
      For example, try selecting the highlighted text…`,
    navDotAriaLabel: 'Go to step 3',
  },
```

... produces this markup...

```
<button data-tour-elem="dot" class="sc-htoDjs fyrYpc reactour__dot" aria-label="Go to step 3"></button>
```