### PR TITLE
fix: unable to position in center if first step has no DOM node

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -201,12 +201,16 @@ function Tour({
         makeCalculations(nodeRect, step.position)
       }
     } else {
+      const { width: helperWidth, height: helperHeight } = getNodeRect(helper.current);
       dispatch({
         type: 'NO_DOM_NODE',
         helperPosition: step.position,
         w,
         h,
         inDOM: false,
+        helperWidth,
+        helperHeight,
+        helper: helper.current
       })
     }
 
@@ -408,9 +412,11 @@ function reducer(state, action) {
         top: state.h + 10,
         right: state.w / 2 + 9,
         bottom: state.h / 2 + 9,
-        left: action.w / 2 - state.helperWidth ? state.helperWidth / 2 : 0,
+        left: action.w / 2 - action.helperWidth ? action.helperWidth / 2 : 0,
         width: 0,
         height: 0,
+        helperWidth: action.helperWidth,
+        helperHeight: action.helperHeight,
         w: action.w,
         h: action.h,
         helperPosition: 'center',


### PR DESCRIPTION
In the latest version if the first step is intended as a modal in the center of the screen and no DOM selector is passed, the `Guide` renders at the top left of the screen because it doesn't know the dimensions of the helper and the props passed to the `Guide` styled-component produce `NaN` px transform values.