### PR TITLE
Handle unmount during timeout

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -61,7 +61,7 @@ class Tour extends Component {
 
     if (isOpen && update !== nextProps.update) {
       if (nextProps.steps[this.state.current]) {
-        setTimeout(this.showStep, updateDelay)
+        setTimeout(() => this.helper.current && this.showStep(), updateDelay)
       } else {
         this.props.onRequestClose()
       }


### PR DESCRIPTION
Fixes a problem where the `Tour` is disposed after the delayed `showStep` is initiated from `componentWillReceiveProps`:

```
Error: Uncaught [TypeError: Cannot read property 'getBoundingClientRect' of null]
    at reportException (/Users/tom/code/console/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:62:24)
    at Timeout.callback [as _onTimeout] (/Users/tom/code/console/node_modules/jsdom/lib/jsdom/browser/Window.js:645:7)
    at listOnTimeout (internal/timers.js:535:17)
    at processTimers (internal/timers.js:479:7) TypeError: Cannot read property 'getBoundingClientRect' of null
    at getNodeRect (/Users/tom/code/console/node_modules/reactour/dist/reactour.cjs.js:266:36)
    at setNodeState (/Users/tom/code/console/node_modules/reactour/dist/reactour.cjs.js:1219:25)
    at Tour.showStep (/Users/tom/code/console/node_modules/reactour/dist/reactour.cjs.js:812:24)
    at setTimeout (/Users/tom/code/console/node_modules/reactour/dist/reactour.cjs.js:1000:70)
    at Timeout.callback [as _onTimeout] (/Users/tom/code/console/node_modules/jsdom/lib/jsdom/browser/Window.js:643:19)
    at listOnTimeout (internal/timers.js:535:17)
    at processTimers (internal/timers.js:479:7)
```

(Similar issue to #18)
