### PR TITLE
Fix start step actionBefore

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -95,6 +95,7 @@ function Tour({
           'center'
         )
         setCurrent(startAt)
+        showStep(startAt)
       } else {
         showStep()
       }


### PR DESCRIPTION
ensure initial open triggers the opening steps `actionBefore` function.

Prior to this change it was not getting executed due to `showStep` not being called.