### PR TITLE
Add role="dialog" for accessibility

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -300,6 +300,7 @@ function Tour({
           className={cn(CN.helper.base, className, {
             [CN.helper.isOpen]: isOpen,
           })}
+          role="dialog"
         >
           {CustomHelper ? (
             <CustomHelper


### PR DESCRIPTION
Modal dialogs should have `role="dialog"` for accessibility. 
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role

In the future, can use `<dialog>` instead.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
https://caniuse.com/#feat=dialog