### PR TITLE
aria-label option for close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Type: `node | elem`
 
 Type: `string`
 
+#### closeButtonAriaLabel
+
+> `aria-label` attribute for the close button (for accessibility)
+
+Type: `string`
+
 #### closeWithMask
 
 > Close the _Tour_ by clicking the _Mask_

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Type: `string`
 
 Type: `string`
 
+Default: `'Close'`
+
 #### closeWithMask
 
 > Close the _Tour_ by clicking the _Mask_

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -15,6 +15,7 @@ import {
   Arrow,
   Navigation,
   Dot,
+  Close,
 } from './components/index'
 import { getNodeRect, getWindow, inView, isBody } from './helpers'
 import { propTypes, defaultProps } from './propTypes'
@@ -49,6 +50,8 @@ function Tour({
   nextButton,
   rounded,
   maskSpace,
+  showCloseButton,
+  closeButtonAriaLabel,
 }) {
   const [current, setCurrent] = useState(0)
   const [started, setStarted] = useState(false)

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -389,6 +389,9 @@ function Tour({
                   )}
                 </Controls>
               )}
+              {showCloseButton && (
+                <Close onClick={close} ariaLabel={closeButtonAriaLabel} />
+              )}
             </>
           )}
         </Guide>

--- a/src/components/Close.js
+++ b/src/components/Close.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 function Close({ className, onClick, ariaLabel }) {
   return (
     <SvgButton className={className} onClick={onClick} aria-label={ariaLabel}>
-      <svg viewBox="0 0 9.1 9.1">
+      <svg viewBox="0 0 9.1 9.1" aria-hidden role="presentation">
         <path
           fill="currentColor"
           d="M5.9 4.5l2.8-2.8c.4-.4.4-1 0-1.4-.4-.4-1-.4-1.4 0L4.5 3.1 1.7.3C1.3-.1.7-.1.3.3c-.4.4-.4 1 0 1.4l2.8 2.8L.3 7.4c-.4.4-.4 1 0 1.4.2.2.4.3.7.3s.5-.1.7-.3L4.5 6l2.8 2.8c.3.2.5.3.8.3s.5-.1.7-.3c.4-.4.4-1 0-1.4L5.9 4.5z"

--- a/src/components/Close.js
+++ b/src/components/Close.js
@@ -3,9 +3,9 @@ import styled from 'styled-components'
 import SvgButton from './SvgButton'
 import PropTypes from 'prop-types'
 
-function Close({ className, onClick }) {
+function Close({ className, onClick, ariaLabel }) {
   return (
-    <SvgButton className={className} onClick={onClick}>
+    <SvgButton className={className} onClick={onClick} aria-label={ariaLabel}>
       <svg viewBox="0 0 9.1 9.1">
         <path
           fill="currentColor"
@@ -19,6 +19,7 @@ function Close({ className, onClick }) {
 Close.propTypes = {
   className: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  ariaLabel: PropTypes.string,
 }
 
 const StyledClose = styled(Close)`

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -5,6 +5,7 @@ export const propTypes = {
   highlightedMaskClassName: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
   className: PropTypes.string,
+  closeButtonAriaLabel: PropTypes.string,
   closeWithMask: PropTypes.bool,
   inViewThreshold: PropTypes.number,
   isOpen: PropTypes.bool.isRequired,

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -65,6 +65,7 @@ export const defaultProps = {
   showNavigationNumber: true,
   showButtons: true,
   showCloseButton: true,
+  closeButtonAriaLabel: 'Close',
   showNumber: true,
   startAt: 0,
   scrollDuration: 1,


### PR DESCRIPTION
The close (X) button has no label but buttons and form controls need some kind of label for accessibility. So adding a `closeButtonAriaLabel` prop to `<Tour>` to add an `aria-label` to the button.

Also, hiding the elements within the button from screen readers. From accessibility auditor:
> Hide the inner SVG from AT by putting role="presentation" and aria-hidden="true" on it, then add an aria-label attribute on the <button> element.