### PR TITLE
prop to hide nav from screen readers, combine a11y props

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ Type: `string`
 
 Default: `#007aff`
 
+#### accessibilityOptions
+
+> Configure accessibility related accessibility options
+
+Type: `object`
+
+Default:
+```js
+    // attribute to associate the dialog with a title for screen readers
+    ariaLabelledBy: null,
+    // aria-label attribute for the close button
+    closeButtonAriaLabel: 'Close',
+    // Show/Hide Navigation Dots for screen reader software
+    showNavigationScreenReaders: true,
+```
+
 #### badgeContent
 
 > Customize _Badge_ content using `current` and `total` steps values
@@ -86,12 +102,6 @@ Type: `func`
 // example
 <Tour badgeContent={(curr, tot) => `${curr} of ${tot}`} />
 ```
-
-#### ariaLabelledBy
-
-> `ariaLabelledBy` attribute to associate the dialog with a title for screen readers (accessibility)
-
-Type: `string`
 
 #### children
 
@@ -104,14 +114,6 @@ Type: `node | elem`
 > Custom class name to add to the _Helper_
 
 Type: `string`
-
-#### closeButtonAriaLabel
-
-> `aria-label` attribute for the close button (for accessibility)
-
-Type: `string`
-
-Default: `'Close'`
 
 #### closeWithMask
 
@@ -303,14 +305,6 @@ Default: `true`
 #### showNavigation
 
 > Show/Hide _Helper_ Navigation Dots
-
-Type: `bool`
-
-Default: `true`
-
-#### showNavigationScreenReaders
-
-> Show/Hide _Helper_ Navigation Dots for screen reader software
 
 Type: `bool`
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,14 @@ Type: `bool`
 
 Default: `true`
 
+#### showNavigationScreenReaders
+
+> Show/Hide _Helper_ Navigation Dots for screen reader software
+
+Type: `bool`
+
+Default: `true`
+
 #### showNavigationNumber
 
 > Show/Hide number when hovers on each Navigation Dot

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -43,6 +43,7 @@ function Tour({
   maskClassName,
   showButtons,
   showNavigation,
+  showNavigationScreenReaders,
   prevButton,
   showNavigationNumber,
   disableDotsNavigation,
@@ -346,7 +347,10 @@ function Tour({
                   )}
 
                   {showNavigation && (
-                    <Navigation data-tour-elem="navigation">
+                    <Navigation
+                      data-tour-elem="navigation"
+                      aria-hidden={!showNavigationScreenReaders}
+                    >
                       {steps.map((s, i) => (
                         <Dot
                           key={`${s.selector ? s.selector : 'undef'}_${i}`}

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -43,7 +43,6 @@ function Tour({
   maskClassName,
   showButtons,
   showNavigation,
-  showNavigationScreenReaders,
   prevButton,
   showNavigationNumber,
   disableDotsNavigation,
@@ -52,14 +51,17 @@ function Tour({
   rounded,
   maskSpace,
   showCloseButton,
-  closeButtonAriaLabel,
-  ariaLabelledBy,
+  accessibilityOptions,
 }) {
   const [current, setCurrent] = useState(0)
   const [started, setStarted] = useState(false)
   const [state, dispatch] = useReducer(reducer, initialState)
   const helper = useRef(null)
   const observer = useRef(null)
+  const a11yOptions = {
+    ...defaultProps.accessibilityOptions,
+    ...accessibilityOptions,
+  }
 
   useMutationObserver(observer, (mutationList, observer) => {
     if (isOpen) {
@@ -312,7 +314,7 @@ function Tour({
             [CN.helper.isOpen]: isOpen,
           })}
           role="dialog"
-          aria-labelledby={ariaLabelledBy}
+          aria-labelledby={a11yOptions.ariaLabelledBy}
         >
           {CustomHelper ? (
             <CustomHelper
@@ -349,7 +351,7 @@ function Tour({
                   {showNavigation && (
                     <Navigation
                       data-tour-elem="navigation"
-                      aria-hidden={!showNavigationScreenReaders}
+                      aria-hidden={!a11yOptions.showNavigationScreenReaders}
                     >
                       {steps.map((s, i) => (
                         <Dot
@@ -396,7 +398,10 @@ function Tour({
                 </Controls>
               )}
               {showCloseButton && (
-                <Close onClick={close} ariaLabel={closeButtonAriaLabel} />
+                <Close
+                  onClick={close}
+                  ariaLabel={a11yOptions.closeButtonAriaLabel}
+                />
               )}
             </>
           )}

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -24,6 +24,7 @@ export const propTypes = {
   showCloseButton: PropTypes.bool,
   showNavigation: PropTypes.bool,
   showNavigationNumber: PropTypes.bool,
+  showNavigationScreenReaders: PropTypes.bool,
   showNumber: PropTypes.bool,
   startAt: PropTypes.number,
   goToStep: PropTypes.number,
@@ -64,6 +65,7 @@ export const propTypes = {
 export const defaultProps = {
   showNavigation: true,
   showNavigationNumber: true,
+  showNavigationScreenReaders: true,
   showButtons: true,
   showCloseButton: true,
   closeButtonAriaLabel: 'Close',

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types'
 
 export const propTypes = {
-  ariaLabelledBy: PropTypes.string,
+  accessibilityOptions: PropTypes.shape({
+    ariaLabelledBy: PropTypes.string,
+    closeButtonAriaLabel: PropTypes.string,
+    showNavigationScreenReaders: PropTypes.bool,
+  }),
   badgeContent: PropTypes.func,
   highlightedMaskClassName: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
   className: PropTypes.string,
-  closeButtonAriaLabel: PropTypes.string,
   closeWithMask: PropTypes.bool,
   inViewThreshold: PropTypes.number,
   isOpen: PropTypes.bool.isRequired,
@@ -24,7 +27,6 @@ export const propTypes = {
   showCloseButton: PropTypes.bool,
   showNavigation: PropTypes.bool,
   showNavigationNumber: PropTypes.bool,
-  showNavigationScreenReaders: PropTypes.bool,
   showNumber: PropTypes.bool,
   startAt: PropTypes.number,
   goToStep: PropTypes.number,
@@ -63,12 +65,14 @@ export const propTypes = {
 }
 
 export const defaultProps = {
+  accessibilityOptions: {
+    closeButtonAriaLabel: 'Close',
+    showNavigationScreenReaders: true,
+  },
   showNavigation: true,
   showNavigationNumber: true,
-  showNavigationScreenReaders: true,
   showButtons: true,
   showCloseButton: true,
-  closeButtonAriaLabel: 'Close',
   showNumber: true,
   startAt: 0,
   scrollDuration: 1,


### PR DESCRIPTION
Prop to hide nav dots from screen reader software.

Combined accessibility related props into a single prop and set defaults.