### PR TITLE
Removed UNSAFE_ prefix from componentWillUnmount

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -76,7 +76,7 @@ class Tour extends Component {
     }
   }
 
-  UNSAFE_componentWillUnmount() {
+  componentWillUnmount() {
     const { isOpen } = this.props
     if (isOpen) {
       this.close()


### PR DESCRIPTION
componentWillUnmount lifecycle is not an UNSAFE method to use [componentWillUnmount Docs](https://reactjs.org/docs/react-component.html#componentwillunmount) and this broke the cleanup of event listeners when parent component that uses reactour gets dismounted.

Fixes https://github.com/elrumordelaluz/reactour/issues/237