### PR TITLE
Hacky fix for error "cannot read property 'getBoundingClientRect'

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -117,6 +117,7 @@ class Tour extends Component {
   }
 
   showStep = () => {
+    if (!this.helper || !this.helper.current) return;
     const { steps } = this.props
     const { current, focusUnlocked } = this.state
     if (focusUnlocked) {


### PR DESCRIPTION
This is definitely not an ideal way of fixing things but since reactour is being rewritten into hooks I figured this warrants the hacky way until the rewritten version becomes mainstream. 