### PR TITLE
Round mask hole

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -400,9 +400,6 @@ class Tour extends Component {
         <Portal>
           <GlobalStyle />
           <SvgMask
-            className={cn(CN.mask.base, maskClassName, {
-              [CN.mask.isOpen]: isOpen,
-            })}
             onClick={this.maskClickHandler}
             forwardRef={c => (this.mask = c)}
             windowWidth={windowWidth}
@@ -413,6 +410,7 @@ class Tour extends Component {
             targetLeft={targetLeft}
             padding={maskSpace}
             rounded={rounded}
+            roundedStep={steps[current].roundedStep}
             className={maskClassName}
             disableInteraction={
               steps[current].stepInteraction === false || disableInteraction

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -375,6 +375,7 @@ class Tour extends Component {
       rounded,
       accentColor,
       CustomHelper,
+      highlightedBorder,
     } = this.props
 
     const {
@@ -418,6 +419,7 @@ class Tour extends Component {
                 : disableInteraction
             }
             disableInteractionClassName={`${CN.mask.disableInteraction} ${highlightedMaskClassName}`}
+            highlightedBorder={highlightedBorder}
           />
           <FocusLock disabled={focusUnlocked}>
             <Guide

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -4,7 +4,8 @@ import * as hx from '../helpers'
 import PropTypes from 'prop-types'
 
 const SvgMaskWrapper = styled.div`
-  opacity: 0.7;
+  opacity: ${props => !props.maskClassName && 0.7};
+  color: ${props => !props.maskClassName && '#000'};
   width: 100%;
   left: 0;
   top: 0;
@@ -12,7 +13,6 @@ const SvgMaskWrapper = styled.div`
   position: fixed;
   z-index: 99999;
   pointer-events: none;
-  color: #000;
 `
 
 export default function SvgMask({
@@ -29,6 +29,7 @@ export default function SvgMask({
   disableInteractionClassName,
   className,
   onClick,
+  highlightedBorder,
 }) {
   const width = hx.safe(targetWidth + padding * 2)
   const height = hx.safe(targetHeight + padding * 2)
@@ -38,7 +39,7 @@ export default function SvgMask({
   const roundedRadius = roundedStep ? Math.min(width / 2, height / 2) : rounded
 
   return (
-    <SvgMaskWrapper onClick={onClick}>
+    <SvgMaskWrapper onClick={onClick} maskClassName={className}>
       <svg
         width={windowWidth}
         height={windowHeight}
@@ -160,6 +161,18 @@ export default function SvgMask({
           display={disableInteraction ? 'block' : 'none'}
           className={disableInteractionClassName}
         />
+        {/* border */}
+        <rect
+          x={hx.safe(left + highlightedBorder.width / 2.0)}
+          y={hx.safe(top + highlightedBorder.width / 2.0)}
+          width={hx.safe(width - highlightedBorder.width)}
+          height={hx.safe(height - highlightedBorder.width)}
+          pointerEvents="auto"
+          fill="none"
+          strokeWidth={highlightedBorder.width}
+          stroke={highlightedBorder.color}
+          rx={roundedRadius - 2}
+        />
       </svg>
     </SvgMaskWrapper>
   )
@@ -177,4 +190,9 @@ SvgMask.propTypes = {
   roundedStep: PropTypes.bool,
   disableInteraction: PropTypes.bool.isRequired,
   disableInteractionClassName: PropTypes.string.isRequired,
+  highlightedBorder: PropTypes.shape({
+    color: PropTypes.string.isRequired,
+    radius: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+  }),
 }

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -162,17 +162,19 @@ export default function SvgMask({
           className={disableInteractionClassName}
         />
         {/* border */}
-        <rect
-          x={hx.safe(left + highlightedBorder.width / 2.0)}
-          y={hx.safe(top + highlightedBorder.width / 2.0)}
-          width={hx.safe(width - highlightedBorder.width)}
-          height={hx.safe(height - highlightedBorder.width)}
-          pointerEvents="auto"
-          fill="none"
-          strokeWidth={highlightedBorder.width}
-          stroke={highlightedBorder.color}
-          rx={roundedRadius - 2}
-        />
+        {highlightedBorder && (
+          <rect
+            x={hx.safe(left + highlightedBorder.width / 2.0)}
+            y={hx.safe(top + highlightedBorder.width / 2.0)}
+            width={hx.safe(width - highlightedBorder.width)}
+            height={hx.safe(height - highlightedBorder.width)}
+            pointerEvents="auto"
+            fill="none"
+            strokeWidth={highlightedBorder.width}
+            stroke={highlightedBorder.color}
+            rx={roundedRadius - 2}
+          />
+        )}
       </svg>
     </SvgMaskWrapper>
   )
@@ -192,7 +194,6 @@ SvgMask.propTypes = {
   disableInteractionClassName: PropTypes.string.isRequired,
   highlightedBorder: PropTypes.shape({
     color: PropTypes.string.isRequired,
-    radius: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
   }),
 }

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -24,6 +24,7 @@ export default function SvgMask({
   targetLeft,
   padding,
   rounded,
+  roundedStep,
   disableInteraction,
   disableInteractionClassName,
   className,
@@ -33,6 +34,8 @@ export default function SvgMask({
   const height = hx.safe(targetHeight + padding * 2)
   const top = hx.safe(targetTop - padding)
   const left = hx.safe(targetLeft - padding)
+
+  const roundedRadius = roundedStep ? Math.min(width / 2, height / 2) : rounded
 
   return (
     <SvgMaskWrapper onClick={onClick}>
@@ -56,56 +59,56 @@ export default function SvgMask({
             <rect
               x={left - 1}
               y={top - 1}
-              width={rounded}
-              height={rounded}
+              width={roundedRadius}
+              height={roundedRadius}
               fill="white"
             />
             <circle
-              cx={left + rounded}
-              cy={top + rounded}
-              r={rounded}
+              cx={left + roundedRadius}
+              cy={top + roundedRadius}
+              r={roundedRadius}
               fill="black"
             />
             {/* top right rounded corner */}
             <rect
-              x={left + width - rounded + 1}
+              x={left + width - roundedRadius + 1}
               y={top - 1}
-              width={rounded}
-              height={rounded}
+              width={roundedRadius}
+              height={roundedRadius}
               fill="white"
             />
             <circle
-              cx={left + width - rounded}
-              cy={top + rounded}
-              r={rounded}
+              cx={left + width - roundedRadius}
+              cy={top + roundedRadius}
+              r={roundedRadius}
               fill="black"
             />
             {/* bottom left rounded corner */}
             <rect
               x={left - 1}
-              y={top + height - rounded + 1}
-              width={rounded}
-              height={rounded}
+              y={top + height - roundedRadius + 1}
+              width={roundedRadius}
+              height={roundedRadius}
               fill="white"
             />
             <circle
-              cx={left + rounded}
-              cy={top + height - rounded}
-              r={rounded}
+              cx={left + roundedRadius}
+              cy={top + height - roundedRadius}
+              r={roundedRadius}
               fill="black"
             />
             {/* bottom right rounded corner */}
             <rect
-              x={left + width - rounded + 1}
-              y={top + height - rounded + 1}
-              width={rounded}
-              height={rounded}
+              x={left + width - roundedRadius + 1}
+              y={top + height - roundedRadius + 1}
+              width={roundedRadius}
+              height={roundedRadius}
               fill="white"
             />
             <circle
-              cx={left + width - rounded}
-              cy={top + height - rounded}
-              r={rounded}
+              cx={left + width - roundedRadius}
+              cy={top + height - roundedRadius}
+              r={roundedRadius}
               fill="black "
             />
           </mask>
@@ -171,6 +174,7 @@ SvgMask.propTypes = {
   targetLeft: PropTypes.number.isRequired,
   padding: PropTypes.number.isRequired,
   rounded: PropTypes.number.isRequired,
+  roundedStep: PropTypes.bool,
   disableInteraction: PropTypes.bool.isRequired,
   disableInteractionClassName: PropTypes.string.isRequired,
 }

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -60,6 +60,11 @@ function App() {
           rounded={5}
           accentColor={accentColor}
           CustomHelper={customComps ? MyCustomHelper : null}
+          highlightedBorder={{
+            color: '#007aff',
+            width: 3,
+            radius: 4,
+          }}
         />
       </Suspense>
     </>

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -133,6 +133,7 @@ const tourConfig = [
     selector: '[data-tut="reactour__logo"]',
     content: 'And this is our cool bus...',
     position: [20, 20],
+    roundedStep: true,
   },
   {
     selector: '[data-tut="reactour__copy"]',

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -60,11 +60,6 @@ function App() {
           rounded={5}
           accentColor={accentColor}
           CustomHelper={customComps ? MyCustomHelper : null}
-          highlightedBorder={{
-            color: '#007aff',
-            width: 3,
-            radius: 4,
-          }}
         />
       </Suspense>
     </>

--- a/src/demo/styles.css
+++ b/src/demo/styles.css
@@ -23,6 +23,7 @@ body {
 
 .mask {
   color: #021d1d;
+  opacity: 0.7
 }
 
 [data-tour-elem='controls'] {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -57,6 +57,11 @@ export const propTypes = {
   ]),
   rounded: PropTypes.number,
   accentColor: PropTypes.string,
+  highlightedBorder: PropTypes.shape({
+    color: PropTypes.string.isRequired,
+    radius: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+  }),
 }
 
 export const defaultProps = {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -44,6 +44,7 @@ export const propTypes = {
       style: PropTypes.object,
       stepInteraction: PropTypes.bool,
       navDotAriaLabel: PropTypes.string,
+      roundedStep: PropTypes.bool,
     })
   ),
   update: PropTypes.string,

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -59,7 +59,6 @@ export const propTypes = {
   accentColor: PropTypes.string,
   highlightedBorder: PropTypes.shape({
     color: PropTypes.string.isRequired,
-    radius: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
   }),
 }


### PR DESCRIPTION
#162 
Add an ability to make a mask hole round by separate prop.
I'm not sure that it was a right decision to implement it for old major version of reactour, but I currently use old version and I need this feature in it. I guess that it can be moved without any problem to master too.