### PR TITLE
Feature/flag to disable focuslock

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,15 @@ Type: `number`
 
 Default: `1`
 
+#### disableFocusLock
+
+> Disable FocusLock component.
+
+Type: `bool`
+
+Default: `false`
+
+
 ## FAQ
 
 <p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactour",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Tourist Guide into your React Components",
   "main": "dist/reactour.cjs.js",
   "module": "dist/reactour.esm.js",

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -96,7 +96,7 @@ class Tour extends Component {
       () => {
         setTimeout(this.showStep, 1)
         this.helperElement = this.helper.current
-        if (!disableFocusLock) this.helper.current.focus()
+        if (!this.props.disableFocusLock) this.helper.current.focus()
         if (onAfterOpen) {
           onAfterOpen(this.helperElement)
         }

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -96,7 +96,7 @@ class Tour extends Component {
       () => {
         setTimeout(this.showStep, 1)
         this.helperElement = this.helper.current
-        this.helper.current.focus()
+        if (!disableFocusLock) this.helper.current.focus()
         if (onAfterOpen) {
           onAfterOpen(this.helperElement)
         }
@@ -374,6 +374,7 @@ class Tour extends Component {
       rounded,
       accentColor,
       CustomHelper,
+      disableFocusLock,
     } = this.props
 
     const {
@@ -420,7 +421,7 @@ class Tour extends Component {
             }
             disableInteractionClassName={`${CN.mask.disableInteraction} ${highlightedMaskClassName}`}
           />
-          <FocusLock disabled={focusUnlocked}>
+          <FocusLock disabled={disableFocusLock}>
             <Guide
               ref={this.helper}
               targetHeight={targetHeight}

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 
 export const propTypes = {
+  disableFocusLock: PropTypes.bool,
   badgeContent: PropTypes.func,
   highlightedMaskClassName: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
@@ -59,6 +60,7 @@ export const propTypes = {
 }
 
 export const defaultProps = {
+  disableFocusLock: false,
   showNavigation: true,
   showNavigationNumber: true,
   showButtons: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,22 +2334,6 @@ errno@^0.1.3, errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-es-abstract@^1.5.1:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.0.tgz#f59d9d44278ea8f90c8ff3de1552537c2fd739b4"
-  integrity sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==
-  dependencies:
-    es-to-primitive "^1.2.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.0"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-inspect "^1.6.0"
-    object-keys "^1.1.1"
-    string.prototype.trimleft "^2.0.0"
-    string.prototype.trimright "^2.0.0"
-
 es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"


### PR DESCRIPTION
Focuslock component used by Reactour sometimes closes menus, dropdowns and modals, affecting page behavior.