### PR TITLE
update inherited corner style with SVG attributes

### DIFF
--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -51,63 +51,7 @@ export default function SvgMask({
               height={windowHeight}
               fill="white"
             />
-            <rect x={left} y={top} width={width} height={height} fill="black" />
-            {/* top left rounded corner */}
-            <rect
-              x={left - 1}
-              y={top - 1}
-              width={rounded}
-              height={rounded}
-              fill="white"
-            />
-            <circle
-              cx={left + rounded}
-              cy={top + rounded}
-              r={rounded}
-              fill="black"
-            />
-            {/* top right rounded corner */}
-            <rect
-              x={left + width - rounded + 1}
-              y={top - 1}
-              width={rounded}
-              height={rounded}
-              fill="white"
-            />
-            <circle
-              cx={left + width - rounded}
-              cy={top + rounded}
-              r={rounded}
-              fill="black"
-            />
-            {/* bottom left rounded corner */}
-            <rect
-              x={left - 1}
-              y={top + height - rounded + 1}
-              width={rounded}
-              height={rounded}
-              fill="white"
-            />
-            <circle
-              cx={left + rounded}
-              cy={top + height - rounded}
-              r={rounded}
-              fill="black"
-            />
-            {/* bottom right rounded corner */}
-            <rect
-              x={left + width - rounded + 1}
-              y={top + height - rounded + 1}
-              width={rounded}
-              height={rounded}
-              fill="white"
-            />
-            <circle
-              cx={left + width - rounded}
-              cy={top + height - rounded}
-              r={rounded}
-              fill="black "
-            />
+            <rect x={left} y={top} width={width} height={height} rx={rounded} fill="black" />
           </mask>
           <clipPath id="clip-path">
             {/* top */}


### PR DESCRIPTION

inherited div style corners replaced with `rx` attribute

as `rx` attribute value in SVG rect element can itself make corners round 
[more info about rx attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx)

