### PR TITLE
Avoid setting node state if helper was destroyed

### DIFF
--- a/src/Tour.js
+++ b/src/Tour.js
@@ -581,6 +581,8 @@ class Tour extends Component {
 }
 
 const setNodeState = (node, step, helper) => {
+  if (!helper) return
+  
   const w = Math.max(
     document.documentElement.clientWidth,
     window.innerWidth || 0


### PR DESCRIPTION
There's a case where the [callback function for smooth scroll](https://github.com/elrumordelaluz/reactour/blob/7dcda2002ace30881d68e990cde99de1ebf845cf/src/Tour.js#L219) is called after the tour has ended or helper was destroyed. The setNodeState throws an error (`Cannot read property 'getBoundingClientRect' of null`) because the helper element is no longer present. 

This can easily be replicated by setting the prop `scrollDuration` to something like 5 seconds and the tour ends before that.

<img width="435" alt="Screenshot 2021-02-19 at 11 52 56 AM" src="https://user-images.githubusercontent.com/11299391/108486789-7c547b80-72c4-11eb-81be-5844b2306643.png">
