### PR TITLE
Let MutationObserver also handle matching node added as child

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,12 +381,12 @@ const steps = [
     // in the highlighted region of the mask. You don't need to add the 
     // step selector here as the default highlighted region is focused on it
     highlightedSelectors: ['[data-tour="highlighted-element"]'],
-    // Array of selectors, each selected node DOM addition/removal will triggered a rerender
-    // of the mask shape. Useful in combinaison with highlightedSelectors when highlighted
+    // Array of selectors, addition/removal of a matching node will trigger a rerender
+    // of the mask shape. Useful in combination with highlightedSelectors when highlighted
     // region of mask should be redrawn after a user action
     mutationObservables: ['[data-tour="mutable-element"]'],
     // Array of selectors, each selected node resize will triggered a rerender of the mask shape.
-    // Useful in combinaison with highlightedSelectors when highlighted region of mask should
+    // Useful in combination with highlightedSelectors when highlighted region of mask should
     // be redrawn after a user action. You should also add the selector in mutationObservables
     // if you want to track DOM addition/removal too
     resizeObservables: ['[data-tour="resizable-parent"]'],

--- a/src/components/MutationObserver.js
+++ b/src/components/MutationObserver.js
@@ -12,9 +12,10 @@ export default ({ step, refresh }) => {
           continue
         }
 
-        const found = step.mutationObservables.find(observable =>
-          node.matches(observable)
-        )
+        const found = step.mutationObservables.find(observable => (
+          node.matches(observable) ||
+          node.querySelector(observable) != null
+        ))
 
         if (found) {
           refresh()

--- a/src/components/ResizeObserver.js
+++ b/src/components/ResizeObserver.js
@@ -16,9 +16,10 @@ export default ({ step, refresh }) => {
           continue
         }
 
-        const found = step.resizeObservables.find(observable =>
-          node.matches(observable)
-        )
+        const found = step.resizeObservables.find(observable => (
+          node.matches(observable) ||
+          node.querySelector(observable) != null
+        ))
 
         if (found) {
           setMutationsCounter(mutationsCounter + 1)


### PR DESCRIPTION
Hi @elrumordelaluz 

First of all, thanks for all your hard work on this package - it is very much appreciated!

**Edit:** Turns out this was also an issue with `resizeObservables`. I have added a fix to that one aswell.

# Issue

When using the `mutationObservables` prop, you specify nodes that you want to listen for mutation events (e.g. added to dom/removed from dom) on. _However_, when the specified node is added to the dom as a **child**, the MutationObserver does not cause a refresh.

# Example

Given the following step:

```js
steps={[
  (...)
  {
    mutationObservables: ['[data-tour="name-input"]']
  },
  (...)
]}
```

and the following DOM:

```html
<form>

</form>
```

If the node is added directly, the MutationObserver functions correctly:

```html
<form>
  <input type="text" data-tour="name-input" /> 
</form>
```

However, if the node is added inside a container, it does not:

```html
<form>
  <div>
    <input type="text" data-tour="name-input" /> 
  </div>
</form>
```

# Solution

Currently, the MutationObserver checks for a match with `node.matches(observable)` where `node` is the removed/added node and `observable` is the given selector.

I have added an additional check `node.querySelector(observable) != null`, to check if the node _contains_ an element matching the selector.