### PR TITLE
Edited readme to highlight the change to named scope and v2 Tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,25 @@
 
 ## Packages
 
-### [@reactour/tour](/packages/tour) 
+This documentation is for the latest release, which uses npm scopes (@reactour). The original (reactour) is now a branch (v1) and its documentation can be found here: [https://github.com/elrumordelaluz/reactour/tree/v1](https://github.com/elrumordelaluz/reactour/tree/v1)
+
+### [@reactour/tour](/packages/tour)
 
 The main package, which uses the other ones to highlight parts of your application from an array of steps.
 
-### [@reactour/mask](/packages/mask) 
+### [@reactour/mask](/packages/mask)
 
 Acustomizable Component to highlight certain element or area of the viewport.
 
-### [@reactour/popover](/packages/popover) 
+### [@reactour/popover](/packages/popover)
 
 A customizable Component to attach to an element or position of the viewport to show content.
 
-### [@reactour/utils](/packages/utils) 
+### [@reactour/utils](/packages/utils)
 
 A set of helper functions used by the other packages.
 
-### [@reactour/playground](/packages/playground) 
+### [@reactour/playground](/packages/playground)
 
 The place where all the stuff is visible working, live [here](https://reactour.vercel.app/).
 


### PR DESCRIPTION
Simple change to highlight that the documentation on the main READme is no longer for the original reactour.