### PR TITLE
Fix clickArea clip path to exactly match the masked area

### DIFF
--- a/packages/mask/README.md
+++ b/packages/mask/README.md
@@ -87,12 +87,12 @@ Prop to customize styles for the different parts of the _Mask_ using a function 
 
 #### Style keys and props available
 
-| key               | props                                                           |
-| ----------------- | --------------------------------------------------------------- |
-| `maskArea`        | `x`, `y`, `width`, `height`                                     |
-| `maskRect`        | `windowWidth`, `windowHeight`, `maskID`                         |
-| `clickArea`       | `windowWidth`, `windowHeight`, `top`, `left`, `width`, `height` |
-| `highlightedArea` | `x`, `y`, `width`, `height`                                     |
+| key               | props                                                  |
+| ----------------- | ------------------------------------------------------ |
+| `maskArea`        | `x`, `y`, `width`, `height`                            |
+| `maskRect`        | `windowWidth`, `windowHeight`, `maskID`                |
+| `clickArea`       | `windowWidth`, `windowHeight`, `clipID`                |
+| `highlightedArea` | `x`, `y`, `width`, `height`                            |
 
 #### Example
 

--- a/packages/mask/src/Mask.tsx
+++ b/packages/mask/src/Mask.tsx
@@ -53,20 +53,9 @@ const Mask: React.FC<MaskProps> = ({
             />
           </mask>
           <clipPath id={clipID}>
-            <rect x={0} y={0} width={windowWidth} height={top} />
-            <rect x={0} y={top} width={left} height={height} />
-            <rect
-              x={left + width + px}
-              y={top}
-              width={safe(windowWidth - width - left)}
-              height={height}
-            />
-            <rect
-              x={0}
-              y={top + height + py}
-              width={windowWidth}
-              height={safe(windowHeight - height - top)}
-            />
+            <polygon points={`0 0, 0 ${windowHeight}, ${left} ${windowHeight}, ${left} ${top}, ${left +
+              width} ${top}, ${left + width} ${top + height}, ${left} ${top +
+              height}, ${left} ${windowHeight}, ${windowWidth} ${windowHeight}, ${windowWidth} 0`}/>
           </clipPath>
         </defs>
 

--- a/packages/mask/src/styles.tsx
+++ b/packages/mask/src/styles.tsx
@@ -1,18 +1,16 @@
-export type StylesKeys =
-  | 'maskWrapper'
-  | 'maskArea'
-  | 'maskRect'
-  | 'clickArea'
-  | 'highlightedArea'
+import { CSSObject } from '@emotion/react'
 
-export type StylesObj = {
-  [key in StylesKeys]?: StyleFn
-}
+export type StyleFn = (props: StyleFnProps, state?: StyleFnProps) => CSSObject
 
-export type StyleFn = (
-  props: { [key: string]: any },
-  state?: { [key: string]: any }
-) => React.CSSProperties
+export type StyleFnProps = CSSObject &
+  Partial<{
+    x: number
+    y: number
+    windowWidth: number
+    windowHeight: number
+    maskID: string
+    clipID: string
+  }>
 
 export type Styles = {
   maskWrapper: StyleFn
@@ -22,7 +20,14 @@ export type Styles = {
   highlightedArea: StyleFn
 }
 
+export type StylesObj = Partial<Styles>
+
 export type StyleKey = keyof Styles
+
+/**
+ * @deprecated Use `StyleKey` alias instead.
+ */
+export type StylesKeys = StyleKey
 
 export const defaultStyles: Styles = {
   maskWrapper: () => ({
@@ -50,18 +55,7 @@ export const defaultStyles: Styles = {
     fill: 'currentColor',
     mask: `url(#${maskID})`,
   }),
-  clickArea: ({
-    windowWidth,
-    windowHeight,
-    top,
-    left,
-    width,
-    height,
-    clipID,
-  }) => ({
-    '--clip-path': `polygon(0 0, 0 ${windowHeight}px, ${left}px ${windowHeight}px, ${left}px ${top}px, ${left +
-      width}px ${top}px, ${left + width}px ${top + height}px, ${left}px ${top +
-      height}px, ${left}px ${windowHeight}px, ${windowWidth}px ${windowHeight}px, ${windowWidth}px 0)`,
+  clickArea: ({ windowWidth, windowHeight, clipID }) => ({
     x: 0,
     y: 0,
     width: windowWidth,
@@ -84,7 +78,7 @@ export const defaultStyles: Styles = {
 export type getStylesType = (key: StylesKeys, extra?: any) => {}
 
 export function stylesMatcher(styles: StylesObj) {
-  return (key: StyleKey, state: {}): {} => {
+  return (key: StyleKey, state: {}): CSSObject => {
     const base = defaultStyles[key](state)
     const custom = styles[key]
     return custom ? custom(base, state) : base


### PR DESCRIPTION
This fixes the clickableArea masking/clipping, which was recently broken due to a fix for Windows https://github.com/elrumordelaluz/reactour/issues/369

(see my comment: https://github.com/elrumordelaluz/reactour/commit/4ee9b2a2f35bbe237a6d75849a46900c4c0e176c#r56992867)

Before the fix the clickableArea would incorrectly add the padding as a gap, resulting in empty spaces which could not be clicked (red: clickableArea, blue: highlightedArea, green: maskedArea):

<img width="857" alt="Screen shot of the incorrect clickableArea" src="https://user-images.githubusercontent.com/741407/139523397-7c0d2666-1da1-4872-a21e-50b9afc8dc62.png">

After the fix the areas once again are an exact match.

It also uses an SVG polygon implementation, more similar to the CSS solution in place before the revert https://github.com/elrumordelaluz/reactour/issues/369
