### PR TITLE
Set inViewThreshold with x, y values or single value

### DIFF
--- a/packages/tour/README.md
+++ b/packages/tour/README.md
@@ -471,7 +471,7 @@ Activate `smooth` scroll behavior when steps are outside viewport.
 
 default: `false`
 
-### `inViewThreshold?: number`
+### `inViewThreshold?: { x: number, y: number } | number`
 
 Tolerance in pixels to add when calculating if the step element is outside viewport to scroll into view.
 

--- a/packages/tour/src/hooks.tsx
+++ b/packages/tour/src/hooks.tsx
@@ -15,7 +15,7 @@ let initialState = {
 
 export function useSizes(
   step: StepType,
-  scrollOptions: ScrollIntoViewOptions & { inViewThreshold?: number } = {
+  scrollOptions: ScrollIntoViewOptions & { inViewThreshold?: number | { x: number, y: number } } = {
     block: 'center',
     behavior: 'smooth',
     inViewThreshold: 0,

--- a/packages/tour/src/types.tsx
+++ b/packages/tour/src/types.tsx
@@ -29,7 +29,7 @@ type SharedProps = {
   showCloseButton?: boolean
   showBadge?: boolean
   scrollSmooth?: boolean
-  inViewThreshold?: number
+  inViewThreshold?: number | { x: number, y: number }
   accessibilityOptions?: A11yOptions
   rtl?: boolean
   components?: PopoverComponentsType

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -173,7 +173,7 @@ type InViewArgs = {
   left: number
   bottom?: number
   right?: number
-  threshold?: number
+  threshold?: { x: number, y: number } | number
 }
 ```
 

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -7,6 +7,19 @@ export function safe(sum: number): number {
   return sum < 0 ? 0 : sum
 }
 
+function getInViewThreshold(threshold: InViewArgs['threshold']) {
+  if (typeof threshold === 'object' && threshold !== null) {
+    return {
+      thresholdX: threshold.x,
+      thresholdY: threshold.y,
+    }
+  }
+  return {
+    thresholdX: threshold || 0,
+    thresholdY: threshold || 0,
+  }
+}
+
 export function getWindow(): { w: number; h: number } {
   const w = Math.max(
     document.documentElement.clientWidth,
@@ -24,19 +37,21 @@ export function inView({
   right,
   bottom,
   left,
-  threshold = 0,
+  threshold,
 }: InViewArgs): boolean {
   const { w: windowWidth, h: windowHeight } = getWindow()
+  const { thresholdX, thresholdY } = getInViewThreshold(threshold)
+
   return top < 0 && bottom - top > windowHeight
     ? true
-    : top >= 0 + threshold &&
-        left >= 0 + threshold &&
-        bottom <= windowHeight - threshold &&
-        right <= windowWidth - threshold
+    : top >= 0 + thresholdY &&
+        left >= 0 + thresholdX &&
+        bottom <= windowHeight - thresholdY &&
+        right <= windowWidth - thresholdX
 }
 
 type InViewArgs = RectResult & {
-  threshold?: number
+  threshold?: { x: number; y: number } | number
 }
 
 export const isHoriz = (pos: string) => /(left|right)/.test(pos)


### PR DESCRIPTION
That will be usefull, when you have static bar at the top of the page, and some elements, which must be highlighted, hiding under that bar.

If you use threshold as single number, popup will be wobbling, if highlighted element closer to left\right border, than width of the static bar.