### PR TITLE
Fix issue with mask border radius on Safari

### DIFF
--- a/packages/mask/src/Mask.tsx
+++ b/packages/mask/src/Mask.tsx
@@ -25,6 +25,13 @@ const Mask: React.FC<MaskProps> = ({
   const top = safe(sizes?.top - py)
   const left = safe(sizes?.left - px)
 
+  const maskAreaStyles = getStyles('maskArea', {
+    x: left,
+    y: top,
+    width,
+    height
+  });
+
   return (
     <div
       css={getStyles('maskWrapper', {})}
@@ -46,12 +53,9 @@ const Mask: React.FC<MaskProps> = ({
               fill="white"
             />
             <rect
-              css={getStyles('maskArea', {
-                x: left,
-                y: top,
-                width,
-                height,
-              })}
+              css={maskAreaStyles}
+              // Needs for Safari, as we pass any value, css rx will apply.
+              rx={maskAreaStyles.rx ? 1 : undefined}
             />
           </mask>
           <clipPath id={clipID}>


### PR DESCRIPTION
Fixed issue with mask border radius (rx) style when using Safari.
Visual proof.

<img width="1088" alt="Знімок екрана 2022-02-19 о 13 26 40" src="https://user-images.githubusercontent.com/44266854/154799004-2854f493-2ca3-4a1e-8352-51d6ed50e91e.png">
