### PR TITLE
fix: getHighlightedRect not consider computed style

### DIFF
--- a/packages/tour/src/hooks.tsx
+++ b/packages/tour/src/hooks.tsx
@@ -121,6 +121,14 @@ function getHighlightedRect(
       continue
     }
 
+    const computedStyle = getComputedStyle(element)
+    if (
+      computedStyle.display === 'none' ||
+      computedStyle.visibility === 'hidden'
+    ) {
+      continue
+    }
+
     const rect = getRect(element)
     hasHighligtedElems = true
     if (bypassElem || !node) {


### PR DESCRIPTION
```html
<div class="a"></div>
<div class="b"></div>
<style>
.a {
  display: none
}
.b {
  position: relative;
  left: 200px;
  top: 200px;
  height: 100px;
  width: 100px;
}
</style>
```
```ts
highlightedSelectors: [
    '.a',
    '.b',
  ]
```

fix computed wrong highlight area(area from [0, 0] to [300, 300]) the situation above, correct area should be from [200, 200] to [300, 300]