### PR TITLE
[tour] Export `StylesObj` type

### DIFF
--- a/packages/tour/types.tsx
+++ b/packages/tour/types.tsx
@@ -157,4 +157,4 @@ export type NavButtonProps = {
   kind?: 'next' | 'prev'
   hideArrow?: boolean
 }
-export type { Position }
+export type { Position, StylesObj }


### PR DESCRIPTION
The mask and popover packages export their own `StylesObj` types, but the tour package does not export its own `StylesObj`. This change adds `StylesObj` as an export.

Please let me know if you would prefer for it to be named `TourStylesObj` and I can update the PR.