### PR TITLE
[tour] Export `StyleObj` type from package

### DIFF
--- a/packages/tour/index.tsx
+++ b/packages/tour/index.tsx
@@ -12,5 +12,6 @@ export type {
   TourProps,
   PopoverContentProps,
   KeyboardParts,
+  StyleObj,
 } from './types'
 export { components } from './components'


### PR DESCRIPTION
This is a follow-on PR from #524. In #524, we added `StyleObj` to the tour package’s `types.tsx` file. In this commit, we export `StyleObj` from the consumable `@reactour/tour` package.