### PR TITLE
fix: disableInteraction cannot be override by step config

### DIFF
--- a/packages/tour/Tour.tsx
+++ b/packages/tour/Tour.tsx
@@ -93,7 +93,7 @@ const Tour: React.FC<TourProps> = ({
     }
   }
 
-  const doDisableInteraction = step?.stepInteraction
+  const doDisableInteraction = typeof step?.stepInteraction === 'boolean'
     ? !step?.stepInteraction
     : disableInteraction
 


### PR DESCRIPTION
Inline `if` checks only value of `step?.stepInteraction` and fallbacks to `disableInteraction` variable if stepInteraction is `false`, so you cannot disable stepInteraction from level of one step config

We should check if `step?.stepInteraction` is defined (is bool)