### PR TITLE
feat: allow providing custom props from highlighted area `rect`

### DIFF
--- a/packages/mask/Mask.tsx
+++ b/packages/mask/Mask.tsx
@@ -13,7 +13,9 @@ const Mask: React.FC<MaskProps> = ({
   highlightedAreaClassName,
   maskId,
   clipId,
+  highlightedAreaRectProps,
 }) => {
+  console.log(highlightedAreaRectProps)
   const maskID = maskId || uniqueId('mask__')
   const clipID = clipId || uniqueId('clip__')
   const getStyles = stylesMatcher(styles)
@@ -98,6 +100,7 @@ const Mask: React.FC<MaskProps> = ({
           })}
         />
         <rect
+          {...highlightedAreaRectProps}
           style={getStyles('highlightedArea', {
             x: left,
             y: top,
@@ -124,6 +127,7 @@ export type MaskProps = {
   onClickHighlighted?: MouseEventHandler<SVGRectElement>
   maskId?: string
   clipId?: string
+  highlightedAreaRectProps?: React.SVGAttributes<SVGRectElement>
 }
 
 export default Mask

--- a/packages/tour/Tour.tsx
+++ b/packages/tour/Tour.tsx
@@ -24,6 +24,7 @@ const Tour: React.FC<TourProps> = ({
   className = 'reactour__popover',
   maskClassName = 'reactour__mask',
   highlightedMaskClassName,
+  highlightedAreaRectProps,
   disableInteraction,
   // disableFocusLock,
   disableKeyboardNavigation,
@@ -154,6 +155,7 @@ const Tour: React.FC<TourProps> = ({
         className={maskClassName}
         onClickHighlighted={onClickHighlighted}
         wrapperPadding={wrapperPadding}
+        highlightedAreaRectProps={highlightedAreaRectProps}
       />
 
       <Popover

--- a/packages/tour/tsconfig.json
+++ b/packages/tour/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
+    "jsx": "react",
     "lib": ["dom"]
   }
 }

--- a/packages/tour/types.tsx
+++ b/packages/tour/types.tsx
@@ -23,6 +23,7 @@ type SharedProps = {
   className?: string
   maskClassName?: string
   highlightedMaskClassName?: string
+  highlightedAreaRectProps?: React.SVGAttributes<SVGRectElement>
   nextButton?: (props: BtnFnProps) => ReactNode | null
   prevButton?: (props: BtnFnProps) => ReactNode | null
   afterOpen?: (target: Element | null) => void


### PR DESCRIPTION
## Description
Allow providing custom SVG `rect` props for highlighted area. This helps fix the problem that current version of Safari (12.6) still has with styling `rect` with CSS.

For example 
```
<rect style="rx: 8px;" />    // this doesn't work
<rect rx="8" />.             // this works
```
<img width="1337" alt="Screenshot 2023-02-06 at 15 25 35" src="https://user-images.githubusercontent.com/6280802/216923228-05efec4f-a144-4f52-b901-fb7e95f16be9.png">
<img width="1337" alt="Screenshot 2023-02-06 at 15 25 11" src="https://user-images.githubusercontent.com/6280802/216923187-5f60c78c-3e3d-4a36-9da3-434a0d03e221.png">


