### PR TITLE
feat: allow to set mask clip ID from TourProvider

### DIFF
--- a/apps/web/components/Home.tsx
+++ b/apps/web/components/Home.tsx
@@ -32,6 +32,8 @@ export default function Home() {
     return () => window.removeEventListener('keyup', keyHandling)
   }, [setIsOpen])
 
+  useEffect(() => setIsOpen(true))
+
   return (
     <>
       <Section center classic>
@@ -40,6 +42,10 @@ export default function Home() {
           Tourist Guide into your React Components
         </Heading>
       </Section>
+      <Section center classic>
+        <Button id="demo-hlt-button">Demo Highlighted Button</Button>
+      </Section>
+
       <Section
         classic
         style={{

--- a/apps/web/components/config.tsx
+++ b/apps/web/components/config.tsx
@@ -5,9 +5,28 @@ import { Link } from './Button'
 
 const tourConfig: StepType[] = [
   {
-    selector: '[data-tut="reactour__iso"]',
+    selector: '#demo-hlt-button',
     content:
       "Ok, let's start with the name of the Tour that is about to begin.",
+    padding: {
+      mask: [0.1, 0.1],
+    },
+    styles: {
+      maskArea: (base) => ({
+        ...base,
+        rx: 4,
+      }),
+      highlightedArea: (base) => ({
+        ...base,
+        display: 'block',
+        pointerEvents: 'none',
+        cursor: 'pointer',
+        stroke: 'red',
+        rx: 4,
+        animation: 'mask-ping 2s ease infinite',
+        clipPath: 'url("#demo-mask-clip")',
+      }),
+    },
   },
   {
     selector: '[data-tut="reactour__logo"]',

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -52,6 +52,7 @@ function App() {
         }}
         // inViewThreshold={40}
         scrollSmooth
+        maskClipId="demo-mask-clip"
       >
         <ModalProvider
           modals={modals}

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -101,3 +101,17 @@ html {
   border-bottom: var(--rtp-arrow-border-bottom);
   border-left: var(--rtp-arrow-border-left);
 }
+
+@keyframes mask-ping {
+  0% {
+    stroke-width: 0;
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    stroke-width: 16px;
+    opacity: 0;
+  }
+}

--- a/packages/tour/Tour.tsx
+++ b/packages/tour/Tour.tsx
@@ -24,6 +24,7 @@ const Tour: React.FC<TourProps> = ({
   className = 'reactour__popover',
   maskClassName = 'reactour__mask',
   highlightedMaskClassName,
+  maskClipId,
   disableInteraction,
   // disableFocusLock,
   disableKeyboardNavigation,
@@ -93,9 +94,10 @@ const Tour: React.FC<TourProps> = ({
     }
   }
 
-  const doDisableInteraction = typeof step?.stepInteraction === 'boolean'
-    ? !step?.stepInteraction
-    : disableInteraction
+  const doDisableInteraction =
+    typeof step?.stepInteraction === 'boolean'
+      ? !step?.stepInteraction
+      : disableInteraction
 
   useEffect(() => {
     if (step?.action && typeof step?.action === 'function') {
@@ -154,6 +156,7 @@ const Tour: React.FC<TourProps> = ({
         className={maskClassName}
         onClickHighlighted={onClickHighlighted}
         wrapperPadding={wrapperPadding}
+        clipId={maskClipId}
       />
 
       <Popover

--- a/packages/tour/types.tsx
+++ b/packages/tour/types.tsx
@@ -23,6 +23,7 @@ type SharedProps = {
   className?: string
   maskClassName?: string
   highlightedMaskClassName?: string
+  maskClipId?: string
   nextButton?: (props: BtnFnProps) => ReactNode | null
   prevButton?: (props: BtnFnProps) => ReactNode | null
   afterOpen?: (target: Element | null) => void


### PR DESCRIPTION
Currently, I need a way to get the Mask clip ID in order to create some animation. For example, a pulse effect around the button to guide user to click on it. 
My suggestion is that we allow specify mask clip ID from TourProvider. Please check it out.

Edit: This is the animation that I want to achieve, included in the preview.
![2023-02-21 15 34 56](https://user-images.githubusercontent.com/6280802/220291242-bd9abdae-0de3-4184-9f15-7ada90c62857.gif)
