### PR TITLE
Remove lodash.pick - Security Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "classnames": "2.3.1",
     "focus-outline-manager": "^1.0.2",
     "lodash.debounce": "4.0.8",
-    "lodash.pick": "4.4.0",
     "prop-types": "15.7.2",
     "react-focus-lock": "2.5.2",
     "scroll-smooth": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactour",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Tourist Guide into your React Components",
   "main": "dist/reactour.cjs.js",
   "module": "dist/reactour.esm.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4504,11 +4504,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.pick@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"


### PR DESCRIPTION
`lodash.pick` has been used initially in [helpers.js](https://github.com/elrumordelaluz/reactour/blob/1dba38b56debd6be49e3b09ee709e519359f424a/src/helpers.js).

This package is no longer used in v1 branch of `reactour`.

The presence of `lodash.pick` in package.json is causing a security vulnerability.

![image](https://github.com/elrumordelaluz/reactour/assets/48859773/8eaa95c1-267b-46fd-8532-bce14046ab4c)

This PR will help removing the security vulnerability.