### PR TITLE
Update Boolean type to boolean

### DIFF
--- a/apps/docs/pages/tour/hooks.mdx
+++ b/apps/docs/pages/tour/hooks.mdx
@@ -52,7 +52,7 @@ function MyComponent() {
     ['steps', 'StepType[]', 'The `array` of steps currently set'],
     [
       'setIsOpen',
-      'Dispatch<React.SetStateAction<Boolean>>',
+      'Dispatch<React.SetStateAction<boolean>>',
       '`useState` function to open or close Tour',
     ],
     [

--- a/apps/docs/pages/tour/props.mdx
+++ b/apps/docs/pages/tour/props.mdx
@@ -338,7 +338,7 @@ Helper functions to customize the Prev button inside [Popover](/popover/quicksta
       ['setCurrentStep', 'Dispatch<React.SetStateAction<number>>'],
       ['stepsLength', 'number'],
       ['currentStep', 'number'],
-      ['setIsOpen', 'Dispatch<React.SetStateAction<Boolean>>'],
+      ['setIsOpen', 'Dispatch<React.SetStateAction<boolean>>'],
     ]}
   />
   <ToggleBox title={<code>NavButtonProps</code>}>
@@ -410,7 +410,7 @@ Useful in case is needed to avoid `onClickMask` when clicking the highlighted el
 <ToggleBox title={<code>ClickProps</code>}>
   <OptionTable
     options={[
-      ['setIsOpen', 'Dispatch<React.SetStateAction<Boolean>>'],
+      ['setIsOpen', 'Dispatch<React.SetStateAction<boolean>>'],
       ['setCurrentStep', 'Dispatch<React.SetStateAction<number>>'],
       ['setSteps', 'Dispatch<React.SetStateAction<StepType[]>>'],
       ['setMeta', 'Dispatch<React.SetStateAction<string>>'],
@@ -580,7 +580,7 @@ Completelly custom component to render inside the [Popover](/popover/quickstart)
       ['currentStep', 'number'],
       ['transition?', 'boolean'],
       ['isHighlightingObserved?', 'boolean'],
-      ['setIsOpen', 'Dispatch<React.SetStateAction<Boolean>>'],
+      ['setIsOpen', 'Dispatch<React.SetStateAction<boolean>>'],
       ['steps', 'StepType[]'],
       ['showNavigation?', 'boolean'],
       ['showPrevNextButtons?', 'boolean'],

--- a/packages/tour/Keyboard.tsx
+++ b/packages/tour/Keyboard.tsx
@@ -77,7 +77,7 @@ export type KeyboardProps = KeyboardHandler & {
   disableKeyboardNavigation?: boolean | KeyboardParts[]
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   currentStep: number
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   stepsLength: number
   disable?: boolean
   rtl?: boolean

--- a/packages/tour/README.md
+++ b/packages/tour/README.md
@@ -370,7 +370,7 @@ type BtnFnProps = {
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   stepsLength: number
   currentStep: number
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
 }
 
 type NavButtonProps = {
@@ -399,7 +399,7 @@ Action fired just before the _Tour_ is closed.
 
 ```ts
 type ClickProps = {
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   setSteps: Dispatch<React.SetStateAction<StepType[]>>
   setMeta: Dispatch<React.SetStateAction<string>>
@@ -420,7 +420,7 @@ Function that overrides the default close behavior of the _Mask_ click handler. 
 
 ```ts
 type ClickProps = {
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   setSteps: Dispatch<React.SetStateAction<StepType[]>>
   setMeta: Dispatch<React.SetStateAction<string>>
@@ -467,7 +467,7 @@ Click handler for highlighted area. Only works when `disableInteraction` is acti
 
 ```ts
 type ClickProps = {
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   setSteps: Dispatch<React.SetStateAction<StepType[]>>
   setMeta: Dispatch<React.SetStateAction<string>>
@@ -641,7 +641,7 @@ type PopoverContentProps = {
   currentStep: number
   transition?: boolean
   isHighlightingObserved?: boolean
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   steps: StepType[]
   showNavigation?: boolean
   showPrevNextButtons?: boolean
@@ -744,7 +744,7 @@ function MyComponent() {
 }
 ```
 
-### `isOpen: Boolean`
+### `isOpen: boolean`
 
 Is the _Tour_ open or close
 
@@ -756,7 +756,7 @@ The current step. **zero based**
 
 The `Array` of steps set currently
 
-### `setIsOpen: Dispatch<React.SetStateAction<Boolean>>`
+### `setIsOpen: Dispatch<React.SetStateAction<boolean>>`
 
 `SetState` function open or close _Tour_
 

--- a/packages/tour/components/Content.tsx
+++ b/packages/tour/components/Content.tsx
@@ -22,7 +22,7 @@ const Content: React.FC<ContentProps> = ({
 export type ContentProps = {
   content: any
   setCurrentStep: Dispatch<React.SetStateAction<number>>
-  setIsOpen?: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen?: Dispatch<React.SetStateAction<boolean>>
   currentStep: number
   transition?: boolean
   isHighlightingObserved?: boolean

--- a/packages/tour/components/Navigation.tsx
+++ b/packages/tour/components/Navigation.tsx
@@ -142,7 +142,7 @@ export type NavigationProps = BaseProps & {
   disableDots?: boolean
   nextButton?: (props: BtnFnProps) => ReactNode | null
   prevButton?: (props: BtnFnProps) => ReactNode | null
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   hideButtons?: boolean
   hideDots?: boolean
   disableAll?: boolean
@@ -153,8 +153,8 @@ export type NavigationProps = BaseProps & {
 export default Navigation
 
 export type ArrowProps = BaseProps & {
-  inverted?: Boolean
-  disabled?: Boolean
+  inverted?: boolean
+  disabled?: boolean
 }
 
 export const DefaultArrow: React.FC<ArrowProps> = ({

--- a/packages/tour/types.tsx
+++ b/packages/tour/types.tsx
@@ -63,7 +63,7 @@ export type PopoverContentProps = {
   currentStep: number
   transition?: boolean
   isHighlightingObserved?: boolean
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   steps: StepType[]
   setSteps?: Dispatch<React.SetStateAction<StepType[]>>
   showNavigation?: boolean
@@ -97,7 +97,7 @@ export type Padding =
 export type KeyboardParts = 'esc' | 'left' | 'right'
 
 export type ClickProps = {
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   currentStep: number
   steps?: StepType[]
@@ -120,7 +120,7 @@ export type KeyboardHandler = {
 
 export type TourProps = SharedProps &
   ClickProps & {
-    isOpen: Boolean
+    isOpen: boolean
     disabledActions: boolean
     disableWhenSelectorFalsy?: boolean
     setDisabledActions: Dispatch<React.SetStateAction<boolean>>
@@ -138,7 +138,7 @@ type BadgeProps = {
 
 export type ProviderProps = SharedProps & {
   children: React.ReactNode
-  defaultOpen?: Boolean
+  defaultOpen?: boolean
   startAt?: number
   setCurrentStep?: Dispatch<React.SetStateAction<number>>
   currentStep?: number
@@ -150,7 +150,7 @@ export type ContentProps = {
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   transition: boolean
   currentStep: number
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
 }
 
 export type StepType = {
@@ -175,7 +175,7 @@ export type BtnFnProps = {
   setCurrentStep: Dispatch<React.SetStateAction<number>>
   stepsLength: number
   currentStep: number
-  setIsOpen: Dispatch<React.SetStateAction<Boolean>>
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>
   steps?: StepType[]
 }
 


### PR DESCRIPTION
As per the typescript docs [here](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#general-types), It says that its best to use the primitive type `boolean` instead of `Boolean`. 

I'm getting unwanted warnings on my project because of `Boolean` being used as the type of `isOpen` as well.

![Screenshot 2024-05-09 at 13 17 36](https://github.com/elrumordelaluz/reactour/assets/84276447/dad4df41-8a74-465f-af86-0356a947493e)


This warning can be removed by using `isOpen.valueOf()` but it feels like overcomplicating things. With that said if someone is already using `valueOf()` it will not break their code.