### PR TITLE
Fix recurring typo (change "Exmple" to "Example")

### DIFF
--- a/apps/docs/pages/tour/props.mdx
+++ b/apps/docs/pages/tour/props.mdx
@@ -111,7 +111,7 @@ Available Components and its `props`
 />
 </ToggleBox>
 
-<ToggleBox title="Exmple">
+<ToggleBox title="Example">
 
 ```js
 import { components } from '@reactour/tour'
@@ -384,7 +384,7 @@ Click handler for highlighted area. Only works when `disableInteraction` is acti
 
 Useful in case is needed to avoid `onClickMask` when clicking the highlighted element.
 
- <ToggleBox title="Exmple">
+ <ToggleBox title="Example">
 
 ```js
 <TourProvider
@@ -431,7 +431,7 @@ Function to handle keyboard events in a custom way.
   Type: `(e: KeyboardEvent, clickProps?: ClickProps, status?: { isEscDisabled?: boolean, isRightDisabled?: boolean, isLeftDisabled?: boolean }) => void`
 </ToggleBox>
 
-<ToggleBox title="Exmple">
+<ToggleBox title="Example">
 
 ```js
 <TourProvider
@@ -594,7 +594,7 @@ Completelly custom component to render inside the [Popover](/popover/quickstart)
   />
 </ToggleBox>
 
-<ToggleBox title="Exmple">
+<ToggleBox title="Example">
 
 ```js
 function ContentComponent(props) {


### PR DESCRIPTION
In this branch, I fixed several instances of a typo (spelling error).

The typo is currently live at: https://docs.react.tours/tour/props

![image](https://github.com/user-attachments/assets/8f179749-8026-4ba9-9c64-0f5b30015150)
