### PR TITLE
Fix ts error about withTour

### DIFF
--- a/packages/tour/withTour.tsx
+++ b/packages/tour/withTour.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { useTour } from './Context'
+import { TourProps } from '.'
 
 export default function withTour<P>(WrappedComponent: React.ComponentType<P>) {
-  const ComponentWithTour = (props: P) => {
+  const ComponentWithTour = (props: Exclude<P, keyof TourProps>) => {
     const tourProps = useTour()
     return <WrappedComponent {...props} {...tourProps} />
   }


### PR DESCRIPTION
In the current implementation, withTour injects tourProps into the WrappedComponent, which means the props of the resulting ComponentWithTour should exclude the keys from TourProps.

## Example

```tsx
import { TourProps } from '...';
import { WithTour } from '...';
import { useTour } from '...';

type DemoProps = {
  data: any
}

const Demo = (props: DemoProps & TourProps)=>{
  return <div>{...}</div>
}

const DemoWithTour = WithTour(Demo);

const App = ()=>{
  const data = [];
  const tourProps = useTour();
  return <div>
    <Demo data={data} {...tourProps} /> // ✅
    <Demo data={data} /> // ❌

    <DemoWithTour data={data} /> //✅
    <DemoWithTour data={data} {...tourProps} /> //❌
  </div>
}
```

In this case, the props of DemoWithTour should only include DemoProps, not DemoProps & TourProps.

To address this, I've updated the prop types of ComponentWithTour to Exclude<P, keyof TourProps> in my pull request.
