### PR TITLE
[Issue-643] Fix the text in Step 12 demo

### DIFF
--- a/apps/web/components/config.tsx
+++ b/apps/web/components/config.tsx
@@ -127,7 +127,7 @@ const tourConfig: StepType[] = [
   {
     selector: '[data-tut="reactour__highlighted"]',
     content:
-      'Moreover you can highlight multiple elements and adjust highlighted region depending on DOM resizes and mutations. Try clicking the "?" tooltip and playing with tabs...',
+      'Moreover you can highlight multiple elements and adjust highlighted region depending on DOM resizes and mutations. Try clicking the "Open Modal" button and playing with tabs...',
     highlightedSelectors: ['[data-tut="reactour__highlighted-absolute-child"]'],
     mutationObservables: ['[data-tut="reactour__highlighted-absolute-child"]'],
     resizeObservables: ['[data-tut="reactour__highlighted-absolute-child"]'],
@@ -135,7 +135,7 @@ const tourConfig: StepType[] = [
   {
     selector: '[data-tour="open_modal"]',
     content:
-      'Moreover you can highlight multiple elements and adjust highlighted region depending on DOM resizes and mutations. Try clicking the "?" tooltip and playing with tabs...',
+      'Moreover you can highlight multiple elements and adjust highlighted region depending on DOM resizes and mutations. Try clicking the "Open Modal" button and playing with tabs...',
     highlightedSelectors: ['.modaaals-modal'],
     mutationObservables: ['#portaaal'],
   },


### PR DESCRIPTION
Fix a copy thing for the demo step 12 as indicated in this Issue 
https://github.com/elrumordelaluz/reactour/issues/643

## After
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/31869fb8-c3dd-46b7-8030-747b0b13856a">

## Before
![image](https://github.com/user-attachments/assets/9ee288c2-d092-424b-beac-87c5fe5fcde1)

demo app link: 
https://reactour-f4orzc4g7-lionels-projects-e9473bc7.vercel.app/