### PR TITLE
fix(docs): carbon ads overlapping entire screen on small desktop

### DIFF
--- a/apps/docs/style.css
+++ b/apps/docs/style.css
@@ -29,6 +29,7 @@ code.text-\[\.9em\] {
 @media (min-width: 768px) {
   #carbonads {
     top: 80px;
+    height: fit-content;
   }
 
   nav.nextra-toc .nextra-scrollbar {


### PR DESCRIPTION
sorry, there is no impressive description, but i hope the title speaks for itself

![image](https://github.com/user-attachments/assets/51672c61-4bf1-45cc-ae4b-8a2ef7d483da)
