### PR TITLE
Implemented `container` and `disablePortal` props

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,22 +1,73 @@
-import { useEffect, useRef } from 'react'
-import { createPortal } from 'react-dom'
+import { useMemo, useLayoutEffect, useEffect, forwardRef, isValidElement, cloneElement } from 'react'
+import { findDOMNode, createPortal } from 'react-dom';
 
-function Portal({ children }) {
-  let ref = useRef(null)
-
-  if (ref.current === null) {
-    ref.current = document.createElement('div')
-    ref.current.setAttribute('id', '___reactour')
+function setRef(ref, value) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
   }
-
-  useEffect(() => {
-    document.body.appendChild(ref.current)
-    return () => {
-      document.body.removeChild(ref.current)
-    }
-  }, [ref])
-
-  return createPortal(children, ref.current)
 }
 
-export default Portal
+function useForkRef(refA, refB) {
+  /**
+   * This will create a new function if the ref props change and are defined.
+   * This means react will call the old forkRef with `null` and the new forkRef
+   * with the ref. Cleanup naturally emerges from this behavior
+   */
+  return useMemo(() => {
+    if (refA == null && refB == null) {
+      return null;
+    }
+    return (refValue) => {
+      setRef(refA, refValue);
+      setRef(refB, refValue);
+    };
+  }, [refA, refB]);
+}
+
+function getContainer(container) {
+  container = typeof container === 'function' ? container() : container;
+  // #StrictMode ready
+  return findDOMNode(container);
+}
+
+const useEnhancedEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+/**
+ * Portals provide a first-class way to render children into a DOM node
+ * that exists outside the DOM hierarchy of the parent component.
+ */
+const Portal = forwardRef(function Portal(props, ref) {
+  const { children, container, disablePortal = false } = props;
+  const [mountNode, setMountNode] = useState(null);
+  const handleRef = useForkRef(isValidElement(children) ? children.ref : null, ref);
+
+  useEnhancedEffect(() => {
+    if (!disablePortal) {
+      setMountNode(getContainer(container) || document.body);
+    }
+  }, [container, disablePortal]);
+
+  useEnhancedEffect(() => {
+    if (mountNode && !disablePortal) {
+      setRef(ref, mountNode);
+      return () => {
+        setRef(ref, null);
+      };
+    }
+
+    return undefined;
+  }, [ref, mountNode, disablePortal]);
+
+  if (disablePortal) {
+    if (isValidElement(children)) {
+      return cloneElement(children, {
+        ref: handleRef,
+      });
+    }
+    return children;
+  }
+
+  return mountNode ? createPortal(children, mountNode) : mountNode;
+});

--- a/src/Tour.js
+++ b/src/Tour.js
@@ -378,6 +378,8 @@ class Tour extends Component {
       CustomHelper,
       disableFocusLock,
       highlightedBorder,
+      container,
+      disablePortal,
     } = this.props
 
     const {
@@ -399,7 +401,7 @@ class Tour extends Component {
 
     if (isOpen) {
       return (
-        <Portal>
+        <Portal container={container} disablePortal={disablePortal}>
           <GlobalStyle />
           <ReactourResizeObserver
             step={steps[current]}

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -63,6 +63,7 @@ export const propTypes = {
     color: PropTypes.string.isRequired,
     width: PropTypes.number.isRequired,
   }),
+  disablePortal: PropTypes.boolean,
 }
 
 export const defaultProps = {


### PR DESCRIPTION
The objetive of this PR is to allow a `container` (and an optional `disablePortal`) prop in order to control where the portal element will be rendered.

The implementation was taken from [Material UI's Portal component](https://github.com/mui/material-ui/blob/v4.x/packages/material-ui/src/Portal/Portal.js).

This implementation addresses some old issues:
- #145 
- #221 

I particularly implemented the feature in order to be able to use reactor in a fullscreen element (similarly to #221 ). If a element is displayed in fullscreen (using the browser's [requestFullscreen method](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen) reactor won't work as the portal will be rendered in `document.body`. This issue is fixed passing `document.fullscreenElement` as the `container` property to the `Tour` component. You can check the following example:

```javascript
function useFullscreenElement() {
  const [fullscreenElement, setFullscreenElement] = useState(
    document?.fullscreenElement
  );
  useEffect(() => {
    const handler = () => {
      setFullscreenElement(document.fullscreenElement);
    };

    document.addEventListener("fullscreenchange", handler);

    return () => {
      document.removeEventListener("fullscreenchange", handler);
    };
  }, []);

  return fullscreenElement;
}

function Component() {
  const fullscreenElement = useFullscreenElement();
  return (
    <Tour
      container={fullscreenElement || document.body}
      { ... }
    />
  );
}
```