### PR TITLE
Add missed ClickProps type export

### DIFF
--- a/packages/tour/index.tsx
+++ b/packages/tour/index.tsx
@@ -13,5 +13,6 @@ export type {
   PopoverContentProps,
   KeyboardParts,
   StylesObj,
+  ClickProps,
 } from './types'
 export { components } from './components'


### PR DESCRIPTION
```
There is ONLY ONE LINE change.
Nothing huge or serious.
```

Hello!
Thank you for your work, you made cool library.

During setuping it on my project I've faced little problem.
I want to declare `onClickClose` function outside, I mean I want to do smth like this:

```tsx
const handleClickClose = (clickProps: NOTYPEFORTHAT) => {/* ... */}

<TourProvider
  /* ... */
  onClickClose=(handleClickClose)
  /* ... */
/>
```

And problem is that there is not `ClickProps` export so I can't properly declare type for `clickProps` in my situation.

I think this is supertiny problem that is much better to made PR by myself than to create issue. So I've did so