### PR TITLE
[ bugFix] - docs: fix typo 'Sapce' -> 'Space' in mask props section

### DIFF
--- a/apps/docs/app/mask/props/page.mdx
+++ b/apps/docs/app/mask/props/page.mdx
@@ -60,7 +60,7 @@ Type: `number | number[]`
 
 Extra space to add between viewport with and height.
 
-<ToggleBox title="Sapce calculation">
+<ToggleBox title="Space calculation">
   Calculation is based on [padding shorthand
   syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/padding#syntax)
   <OptionTable

--- a/apps/docs/app/popover/props/page.mdx
+++ b/apps/docs/app/popover/props/page.mdx
@@ -69,7 +69,7 @@ Type: `number | number[]`
 
 Extra space to add in _Popover_ calculations. Useful when calculating space from _Element_ bounding rect and want to add more space.
 
-<ToggleBox title="Sapce calculation">
+<ToggleBox title="Space calculation">
   Calculation is based on [padding shorthand
   syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/padding#syntax)
   <OptionTable


### PR DESCRIPTION
<img width="1894" height="824" alt="Screenshot 2025-08-26 232459" src="https://github.com/user-attachments/assets/c42ed459-7e79-4efe-af93-6315fd26098c" />
